### PR TITLE
Disable APT by default, upgrade AGDK versions

### DIFF
--- a/agdk/agdktunnel/README.md
+++ b/agdk/agdktunnel/README.md
@@ -12,34 +12,47 @@ AGDKTunnel uses the following AGDK libraries:
 * GameTextInput
 * Oboe
 
-## Prerequisites
-
-### Python
-
-Python is expected to be available in your `PATH`. The `protobuf` package is
-expected to have been installed via `pip`. It is expected that `python`
-is version 3, not version 2.
-
-NOTE: If you are building on Windows, Android Studio may be using its own local
-Python install. Using the `Terminal` tab in Android Studio you can check
-for protobuf using `pip list`. If the protobuf package is not present it can be
-installed by running `pip install protobuf` from the Terminal tab.
-
-### Note for macOS developers
-
-The runtime data files for Android Performance Tuner are compiled using the
-`protoc` compiler located in `third_party/protobuf-3.0.0/install/mac/bin/protoc`.
-This executable is not codesigned or notarized. You may need to adjust your
-Gatekeeper settings or compile your own protoc from the [protobuf](https://github.com/protocolbuffers) repo to build the project if you encounter errors about
-an unsigned executable.
-
 ## Building
 
 Open the `agdktunnel' directory in Android Studio 4.2 or higher.
 
-## Android Performance Tuner API Key
+## Android Performance Tuner (APT)
+
+Android Performance Tuner is disabled by default. To enable it, perform the following steps:
+
+1. Ensure APT build prerequisites are met
+2. Add an APT API key
+3. Enable the APT option in gradle.properties
+
+These steps are described in more detail in the following subsections.
+
+### APT Prerequisites
+
+#### Python
+
+Python is expected to be available in your `PATH`. The `protobuf` package is
+expected to have been installed via `pip`. In some cases, Android Studio may be using an internal
+install of Python rather than a system install. If this is the case, you may need to run
+`pip install protobuf` from the Terminal tab in Android Studio.
+
+#### APT API Key
 
 The APT functionality requires a valid API key to operate. This is not
-necessary to run the sample. For information on configure an API key
+necessary to run the sample. For information on how to configure an API key
 for APT, see the **Get an API key for the Android Performance Tuner**
 section of the Codelab [Integrating Android Performance Tuner into your native Android game](https://developer.android.com/codelabs/android-performance-tuner-native#1).
+
+#### Enable the APT option
+
+To enable building the runtime APT assets and use the library at runtime, edit the
+`gradle.properties` file and change: `APTEnabled=false` to `APTEnabled=true`. When switching
+configurations, it is recommended to sync the gradle file, and run
+**Build -> Refresh Linked C++ Projects** and **Build -> Clean Project** before rebuilding.
+
+#### Note for macOS developers
+
+The runtime data files for Android Performance Tuner are compiled using the
+`protoc` compiler located in `third_party/protobuf-3.0.0/install/mac/bin/protoc`.
+This executable is not codesigned or notarized. You may need to allow execution of the relevant
+files using the **System Preferences -> Security & Privacy** control panel, adjust your
+Gatekeeper settings or compile your own protoc from the [protobuf](https://github.com/protocolbuffers) repo.

--- a/agdk/agdktunnel/app/build.gradle
+++ b/agdk/agdktunnel/app/build.gradle
@@ -18,6 +18,9 @@ import org.gradle.internal.os.OperatingSystem;
 
 apply plugin: 'com.android.application'
 
+// See README for details on enabling APT
+def useApt = APTEnabled
+
 android {
     compileSdkVersion 30
     ndkVersion '21.4.7075529'
@@ -37,7 +40,8 @@ android {
             externalNativeBuild {
                 cmake {
                     arguments "-DANDROID_STL=c++_shared",
-                            "-DUSE_ASSET_PACKS=false"
+                              "-DUSE_ASSET_PACKS=false",
+                              "-DUSE_APT=$useApt"
                 }
             }
         }
@@ -48,7 +52,8 @@ android {
                         'proguard-rules.pro'
                 cmake {
                     arguments "-DANDROID_STL=c++_shared",
-                            "-DUSE_ASSET_PACKS=false"
+                              "-DUSE_ASSET_PACKS=false",
+                              "-DUSE_APT=$useApt"
                 }
             }
             multiDexEnabled true
@@ -72,10 +77,10 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
     implementation 'androidx.fragment:fragment:1.2.5'
     implementation 'com.google.oboe:oboe:1.5.0'
-    implementation "androidx.games:games-frame-pacing:1.10.0-alpha01"
-    implementation "androidx.games:games-performance-tuner:1.5.0-beta02"
-    implementation "androidx.games:games-activity:1.1.0-beta02"
-    implementation "androidx.games:games-controller:1.1.0-alpha01"
+    implementation "androidx.games:games-frame-pacing:1.10.0"
+    implementation "androidx.games:games-performance-tuner:1.5.0"
+    implementation "androidx.games:games-activity:1.1.0"
+    implementation "androidx.games:games-controller:1.1.0"
 
     // Example of using local .aar files in libs/ directory.
     // Comment out the androidx.games implementation lines if
@@ -83,7 +88,7 @@ dependencies {
     //implementation fileTree(dir: 'libs', include: ['GameActivity.aar',
     //                                               'GameController.aar',
     //                                               'games-frame-pacing-1.9.0.aar',
-    //                                               'games-performance-tuner-1.4.3.aar'])
+    //                                               'games-performance-tuner-1.5.0.aar'])
 }
 
 android.lintOptions {
@@ -115,4 +120,6 @@ task buildTuningForkBinFiles(type: Exec) {
             getProtocPath()
 }
 
-tasks.preBuild.dependsOn("buildTuningForkBinFiles")
+if (APTEnabled.toBoolean()) {
+    tasks.preBuild.dependsOn("buildTuningForkBinFiles")
+}

--- a/agdk/agdktunnel/app/src/main/cpp/CMakeLists.txt
+++ b/agdk/agdktunnel/app/src/main/cpp/CMakeLists.txt
@@ -53,6 +53,10 @@ if("${USE_ASSET_PACKS}" STREQUAL "false")
     add_definitions("-DNO_ASSET_PACKS")
 endif()
 
+if("${USE_APT}" STREQUAL "true")
+    add_definitions("-DUSE_APT")
+endif()
+
 set(THIRD_PARTY_DIR ../../../../../third_party)
 # Import the CMakeLists.txt for the glm library
 add_subdirectory(${THIRD_PARTY_DIR}/glm ${CMAKE_CURRENT_BINARY_DIR}/glm)

--- a/agdk/agdktunnel/app/src/main/cpp/tuning_manager.hpp
+++ b/agdk/agdktunnel/app/src/main/cpp/tuning_manager.hpp
@@ -18,8 +18,12 @@
 #define agdktunnel_tuning_manager_hpp
 
 #include "common.hpp"
+
+#if defined(USE_APT)
+// Generated protobuf headers
 #include "nano/dev_tuningfork.pb.h"
 #include "nano/tuningfork.pb.h"
+#endif
 
 struct AConfiguration;
 
@@ -38,7 +42,9 @@ public:
 
     void PostFrameTick(const uint16_t frameKey);
 
+#if defined(USE_APT)
     void SetCurrentAnnotation(const _com_google_tuningfork_Annotation *annotation);
+#endif
 
     void StartLoading();
 

--- a/agdk/agdktunnel/gradle.properties
+++ b/agdk/agdktunnel/gradle.properties
@@ -19,3 +19,7 @@ android.useAndroidX=true
 android.prefabVersion=1.1.3
 
 GameSDKPath=../..
+
+# Set to true to build Android Performance Tuner runtime assets
+# and enable the library at runtime
+APTEnabled=false


### PR DESCRIPTION
Merged from AOSP.

* Updates included AGDK library versions to latest stable
releases
* Compilation of APT runtime data files and APT initialization
is now off by default and controlled by the `APTEnabled` property
in `gradle.properties`
* Updated README with new APT details