### PR TITLE
Fix APT Disabled build issue

### DIFF
--- a/agdk/agdktunnel/app/src/main/cpp/CMakeLists.txt
+++ b/agdk/agdktunnel/app/src/main/cpp/CMakeLists.txt
@@ -31,10 +31,12 @@ set(PROTOBUF_NANO_SRC_DIR "${GAMESDK_BASE_DIR}/third_party/nanopb-c")
 include("${GAMESDK_BASE_DIR}/util/protobuf/protobuf.cmake")
 # Directory of nano protobuf library source files
 include_directories(${PROTOBUF_NANO_SRC_DIR})
-# generate runtime files using protoc
-protobuf_generate_nano_c( ${CMAKE_CURRENT_SOURCE_DIR}/../proto ../proto/dev_tuningfork.proto)
-protobuf_generate_nano_c( ${CMAKE_CURRENT_SOURCE_DIR}/../proto ../proto/tuningfork.proto)
-include_directories(${PROTO_GENS_DIR})
+if("${USE_APT}" STREQUAL "true")
+    # generate runtime files using protoc
+    protobuf_generate_nano_c( ${CMAKE_CURRENT_SOURCE_DIR}/../proto ../proto/dev_tuningfork.proto)
+    protobuf_generate_nano_c( ${CMAKE_CURRENT_SOURCE_DIR}/../proto ../proto/tuningfork.proto)
+    include_directories(${PROTO_GENS_DIR})
+endif()
 
 # common include directory for all samples
 set(COMMON_INCLUDE_DIR "../../../../../common/include")
@@ -62,11 +64,18 @@ set(THIRD_PARTY_DIR ../../../../../third_party)
 # Import the CMakeLists.txt for the glm library
 add_subdirectory(${THIRD_PARTY_DIR}/glm ${CMAKE_CURRENT_BINARY_DIR}/glm)
 
+if("${USE_APT}" STREQUAL "true")
+    set(PROTOGEN_SRCS
+        ${PROTO_GENS_DIR}/nano/dev_tuningfork.pb.c
+        ${PROTO_GENS_DIR}/nano/tuningfork.pb.c)
+else()
+    set(PROTOGEN_SRCS "")
+endif()
+
 # now build app's shared lib
 add_library(game SHARED
      ${PROTOBUF_NANO_SRCS}
-     ${PROTO_GENS_DIR}/nano/dev_tuningfork.pb.c
-     ${PROTO_GENS_DIR}/nano/tuningfork.pb.c
+     ${PROTOGEN_SRCS}
      android_main.cpp
      anim.cpp
      ascii_to_geom.cpp


### PR DESCRIPTION
* Correct issue with CMakeLists.txt where nanopb
files were still attempting generation and inclusion
even if APT is disabled.