### PR TITLE
Update to AGDKTunnel to 2.0.0-alpha01 AGDK libs

### DIFF
--- a/agdk/agdktunnel/app/build.gradle
+++ b/agdk/agdktunnel/app/build.gradle
@@ -119,10 +119,10 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
     implementation 'androidx.fragment:fragment:1.2.5'
     implementation 'com.google.oboe:oboe:1.5.0'
-    implementation "androidx.games:games-frame-pacing:1.10.0"
+    implementation "androidx.games:games-frame-pacing:2.0.0-alpha01"
     implementation "androidx.games:games-performance-tuner:1.5.0"
-    implementation "androidx.games:games-activity:1.1.0"
-    implementation "androidx.games:games-controller:1.1.0"
+    implementation "androidx.games:games-activity:2.0.0-alpha01"
+    implementation "androidx.games:games-controller:2.0.0-alpha01"
     implementation "androidx.games:games-memory-advice:1.0.0-beta01"
 
     // Google Play Games dependencies

--- a/agdk/agdktunnel/app/src/main/cpp/CMakeLists.txt
+++ b/agdk/agdktunnel/app/src/main/cpp/CMakeLists.txt
@@ -76,10 +76,8 @@ add_library(${CMAKE_PROJECT_NAME} SHARED
      anim.cpp
      ascii_to_geom.cpp
      dialog_scene.cpp
-     game_activity_included.cpp
      game_asset_manager.cpp
      game_asset_manifest.cpp
-     game_text_input_included.cpp
      indexbuf.cpp
      input_util.cpp
      jni_util.cpp
@@ -87,7 +85,6 @@ add_library(${CMAKE_PROJECT_NAME} SHARED
      loading_thread.cpp
      memory_consumer.cpp
      data_loader_machine.cpp
-     native_app_glue_included.c
      native_engine.cpp
      obstacle.cpp
      obstacle_generator.cpp
@@ -121,7 +118,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
      android
      atomic
      EGL
-     game-activity::game-activity
+     game-activity::game-activity_static
      oboe::oboe
      games-controller::paddleboat_static
      games-frame-pacing::swappy_static

--- a/agdk/agdktunnel/build.gradle
+++ b/agdk/agdktunnel/build.gradle
@@ -22,7 +22,7 @@ buildscript {
        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.2.1'
     }
 }
 

--- a/agdk/agdktunnel/gradle.properties
+++ b/agdk/agdktunnel/gradle.properties
@@ -15,8 +15,7 @@
 #android.enableJetifier=true
 android.useAndroidX=true
 
-# Use Prefab 1.1.3 containing the fix for header only libraries:
-android.prefabVersion=1.1.3
+android.prefabVersion=2.0.0
 
 GameSDKPath=../..
 

--- a/agdk/agdktunnel/gradle/wrapper/gradle-wrapper.properties
+++ b/agdk/agdktunnel/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-7.4-all.zip


### PR DESCRIPTION
Modifications to use the 2.0.0-alpha01 releases of the AGDK libraries. Required gradle/AGP version updates, removal of includes of gameactivity source and linking against new gameactivity static library.