### PR TITLE
Update game_mode and agde to AGDK 2.0 libs

### DIFF
--- a/agdk/adpf/app/build.gradle
+++ b/agdk/adpf/app/build.gradle
@@ -60,8 +60,8 @@ dependencies {
     implementation "androidx.core:core:1.5.0"
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
     implementation 'androidx.fragment:fragment:1.2.5'
-    implementation "androidx.games:games-activity:1.1.0"
-    implementation "androidx.games:games-frame-pacing:1.9.0"
+    implementation "androidx.games:games-activity:2.0.0-alpha01"
+    implementation "androidx.games:games-frame-pacing:2.0.0-alpha01"
 
     // Example of using local .aar files in libs/ directory.
     // Comment out the androidx.games implementation lines if

--- a/agdk/adpf/app/src/main/cpp/CMakeLists.txt
+++ b/agdk/adpf/app/src/main/cpp/CMakeLists.txt
@@ -25,11 +25,6 @@ find_package(games-frame-pacing REQUIRED CONFIG)
 # Retrieve module passes.
 get_target_property(game-activity-include game-activity::game-activity INTERFACE_INCLUDE_DIRECTORIES)
 
-# Set compiler flags. Those options won't be necessary as prefabs will be updated.
-set_source_files_properties(${game-activity-include}/game-activity/native_app_glue/android_native_app_glue.c PROPERTIES COMPILE_FLAGS -Wno-unused-variable)
-set_source_files_properties(${game-activity-include}/game-text-input/gametextinput.cpp PROPERTIES COMPILE_FLAGS -Wno-return-type)
-set_source_files_properties(${game-activity-include}/game-activity/GameActivity.cpp PROPERTIES COMPILE_FLAGS "-Wno-shadow-field -Wno-return-type -Wno-format")
-
 # Export GameActivity_onCreate(),
 # Refer to: https://github.com/android-ndk/ndk/issues/381.
 set(CMAKE_SHARED_LINKER_FLAGS
@@ -110,11 +105,8 @@ add_library(game SHARED
         android_main.cpp
         box_renderer.cpp
         demo_scene.cpp
-        ${game-activity-include}/game-activity/GameActivity.cpp
-        ${game-activity-include}/game-text-input/gametextinput.cpp
         imgui_manager.cpp
         input_util.cpp
-        ${game-activity-include}/game-activity/native_app_glue/android_native_app_glue.c
         native_engine.cpp
         ndk_helper/JNIHelper.cpp
         ndk_helper/Shader.cpp
@@ -146,7 +138,7 @@ target_link_libraries(game
         android
         bullet3
         imgui
-        game-activity::game-activity
+        game-activity::game-activity_static
         games-frame-pacing::swappy_static
         atomic
         EGL

--- a/agdk/adpf/build.gradle
+++ b/agdk/adpf/build.gradle
@@ -22,7 +22,7 @@ buildscript {
        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:7.2.1'
     }
 }
 

--- a/agdk/adpf/gradle.properties
+++ b/agdk/adpf/gradle.properties
@@ -14,5 +14,4 @@
 android.enableJetifier=true
 android.useAndroidX=true
 
-# Use Prefab 1.1.2 containing the fix for header only libraries:
-android.prefabVersion=1.1.2
+android.prefabVersion=2.0.0

--- a/agdk/adpf/gradle/wrapper/gradle-wrapper.properties
+++ b/agdk/adpf/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/agdk/game_mode/app/build.gradle
+++ b/agdk/game_mode/app/build.gradle
@@ -59,8 +59,8 @@ dependencies {
     implementation "androidx.core:core:1.5.0"
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
     implementation 'androidx.fragment:fragment:1.2.5'
-    implementation "androidx.games:games-activity:1.1.0"
-    implementation "androidx.games:games-frame-pacing:1.9.0"
+    implementation "androidx.games:games-activity:2.0.0-alpha01"
+    implementation "androidx.games:games-frame-pacing:2.0.0-alpha01"
 
     // Example of using local .aar files in libs/ directory.
     // Comment out the androidx.games implementation lines if

--- a/agdk/game_mode/app/src/main/cpp/CMakeLists.txt
+++ b/agdk/game_mode/app/src/main/cpp/CMakeLists.txt
@@ -25,11 +25,6 @@ find_package(games-frame-pacing REQUIRED CONFIG)
 # Retrieve module passes.
 get_target_property(game-activity-include game-activity::game-activity INTERFACE_INCLUDE_DIRECTORIES)
 
-# Set compiler flags. Those options won't be necessary as prefabs will be updated.
-set_source_files_properties(${game-activity-include}/game-activity/native_app_glue/android_native_app_glue.c PROPERTIES COMPILE_FLAGS -Wno-unused-variable)
-set_source_files_properties(${game-activity-include}/game-text-input/gametextinput.cpp PROPERTIES COMPILE_FLAGS -Wno-return-type)
-set_source_files_properties(${game-activity-include}/game-activity/GameActivity.cpp PROPERTIES COMPILE_FLAGS "-Wno-shadow-field -Wno-return-type -Wno-format")
-
 # Export GameActivity_onCreate(),
 # Refer to: https://github.com/android-ndk/ndk/issues/381.
 set(CMAKE_SHARED_LINKER_FLAGS
@@ -110,12 +105,9 @@ add_library(game SHARED
         android_main.cpp
         box_renderer.cpp
         demo_scene.cpp
-        ${game-activity-include}/game-activity/GameActivity.cpp
-        ${game-activity-include}/game-text-input/gametextinput.cpp
         game_mode_manager.cpp
         imgui_manager.cpp
         input_util.cpp
-        ${game-activity-include}/game-activity/native_app_glue/android_native_app_glue.c
         native_engine.cpp
         ndk_helper/JNIHelper.cpp
         ndk_helper/Shader.cpp
@@ -147,7 +139,7 @@ target_link_libraries(game
         android
         bullet3
         imgui
-        game-activity::game-activity
+        game-activity::game-activity_static
         games-frame-pacing::swappy_static
         atomic
         EGL

--- a/agdk/game_mode/build.gradle
+++ b/agdk/game_mode/build.gradle
@@ -22,7 +22,7 @@ buildscript {
        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath 'com.android.tools.build:gradle:7.2.1'
     }
 }
 

--- a/agdk/game_mode/gradle.properties
+++ b/agdk/game_mode/gradle.properties
@@ -14,5 +14,4 @@
 android.enableJetifier=true
 android.useAndroidX=true
 
-# Use Prefab 1.1.2 containing the fix for header only libraries:
-android.prefabVersion=1.1.2
+android.prefabVersion=2.0.0

--- a/agdk/game_mode/gradle/wrapper/gradle-wrapper.properties
+++ b/agdk/game_mode/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip


### PR DESCRIPTION
Modifications to use the 2.0.0-alpha01 releases of the AGDK libraries. Required gradle/AGP version updates, removal of includes of gameactivity source and linking against new gameactivity static library.