### PR TITLE
Add haptic feedback using Library Wrapper

### DIFF
--- a/agdk/agdktunnel/README.md
+++ b/agdk/agdktunnel/README.md
@@ -19,6 +19,10 @@ AGDKTunnel can optionally use the following Play libraries:
 * Play Asset Delivery (via Play core libraries)
 * Input SDK for Google Play Games for PC
 
+AGDKTunnel uses the [Library Wrapper](https://developer.android.com/games/develop/custom/wrapper)
+tool to generate interface files to call the Vibrator API in order to provide haptic
+feedback on in-game collisions.
+
 ## Building
 
 Open the `agdktunnel' directory in Android Studio 2021.2 or higher.
@@ -127,6 +131,20 @@ To enable building the runtime APT assets and use the library at runtime, edit t
 `gradle.properties` file and change: `APTEnabled=false` to `APTEnabled=true`. When switching
 configurations, it is recommended to sync the gradle file, and run
 **Build -> Refresh Linked C++ Projects** and **Build -> Clean Project** before rebuilding.
+
+## Library Wrapper notes
+
+The configuration file used to generate the wrapped Android API is located in
+`agdktunnel/library_wrapper/config.json`. The generated files are located in
+`agdktunnel/app/src/main/cpp/native_wrappers`.
+
+The generation was done by copying the Library Wrapper `lw.jar` file into the root `agdk` directory
+and running the following command from a terminal with `adgk` as the working directory:
+
+`java -jar lw.jar -o "agdktunnel/app/src/main/cpp/native_wrappers" -c "agdktunnel/library_wrapper/config.json"`
+
+For more information on integrating generated wrapper code into your game, see the
+[guide page](https://developer.android.com/games/develop/custom/wrapper-guide).
 
 ## Google Play Games for PC (optional)
 

--- a/agdk/agdktunnel/app/build.gradle
+++ b/agdk/agdktunnel/app/build.gradle
@@ -27,13 +27,13 @@ def usePad = PADEnabled
 def playcoreDir = file('libs/play-core-native-sdk')
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     ndkVersion '23.1.7779620'
 
     defaultConfig {
         applicationId 'com.google.sample.agdktunnel'
         minSdkVersion 24
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode     1
         versionName    '1.0.5'
 
@@ -107,7 +107,10 @@ dependencies {
     implementation "androidx.games:games-performance-tuner:1.5.0"
     implementation "androidx.games:games-activity:2.0.0"
     implementation "androidx.games:games-controller:2.0.0"
-    implementation "androidx.games:games-memory-advice:1.0.0-beta01"
+    implementation "androidx.games:games-memory-advice:2.0.0-beta03"
+
+    // Dependency for using APIs wrapped using library wrapper
+    implementation 'com.google.android.gms:play-services-gni-native-c:1.0.0-beta2'
 
     // Google Play Games dependencies
     implementation "com.google.android.gms:play-services-games-v2:17.0.0"

--- a/agdk/agdktunnel/app/src/main/AndroidManifest.xml
+++ b/agdk/agdktunnel/app/src/main/AndroidManifest.xml
@@ -37,7 +37,8 @@
         android:label="@string/app_name"
         android:configChanges="orientation|keyboardHidden|keyboard|screenSize"
         android:screenOrientation="sensorLandscape"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:exported="true">
       <meta-data android:name="android.app.lib_name"
           android:value="agdktunnel" />
       <intent-filter>
@@ -47,6 +48,7 @@
     </activity>
   </application>
   <uses-feature android:glEsVersion="0x00030000" android:required="true" />
+  <uses-permission android:name="android.permission.VIBRATE" />
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 

--- a/agdk/agdktunnel/app/src/main/cpp/CMakeLists.txt
+++ b/agdk/agdktunnel/app/src/main/cpp/CMakeLists.txt
@@ -16,12 +16,15 @@
 cmake_minimum_required(VERSION 3.4.1)
 project(agdktunnel)
 
+file(GLOB_RECURSE native_wrappers CONFIGURE_DEPENDS "native_wrappers/*.cpp" "native_wrappers/*.cc")
+
 find_package(oboe REQUIRED CONFIG)
 find_package(game-activity REQUIRED CONFIG)
 find_package(games-controller REQUIRED CONFIG)
 find_package(games-frame-pacing REQUIRED CONFIG)
 find_package(games-memory-advice REQUIRED CONFIG)
 find_package(games-performance-tuner REQUIRED CONFIG)
+find_package(com.google.android.gms.gni.c REQUIRED CONFIG)
 
 # Set the base dir
 set(GAMESDK_BASE_DIR "../../../../..")
@@ -49,7 +52,7 @@ set(CMAKE_SHARED_LINKER_FLAGS
 
 # Set common compiler options
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Werror -Wthread-safety" )
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D _LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -Os -fPIC" )
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D _LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -O0 -fPIC" )
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti" )
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGOOGLE_PROTOBUF_NO_RTTI -DHAVE_PTHREAD")
 add_definitions("-DGLM_FORCE_SIZE_T_LENGTH -DGLM_FORCE_RADIANS")
@@ -74,6 +77,7 @@ endif()
 add_library(${CMAKE_PROJECT_NAME} SHARED
      ${PROTOBUF_NANO_SRCS}
      ${PROTOGEN_SRCS}
+     ${native_wrappers}
      android_main.cpp
      anim.cpp
      ascii_to_geom.cpp
@@ -105,6 +109,7 @@ add_library(${CMAKE_PROJECT_NAME} SHARED
      ui_scene.cpp
      util.cpp
      vertexbuf.cpp
+     vibration_manager.cpp
      welcome_scene.cpp
      ${COMMON_SRC_DIR}/Versions.cpp
      )
@@ -117,6 +122,7 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
 
 # add lib dependencies
 target_link_libraries(${CMAKE_PROJECT_NAME}
+     PUBLIC com.google.android.gms.gni.c::gni_shared
      android
      atomic
      EGL
@@ -125,10 +131,13 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
      games-controller::paddleboat_static
      games-frame-pacing::swappy_static
      games-performance-tuner::tuningfork_static
-     games-memory-advice::memory_advice
+     games-memory-advice::memory_advice_static
      GLESv3
      glm
      log)
+
+include_directories(./native_wrappers/c)
+include_directories(./native_wrappers/cpp)
 
 if("${USE_ASSET_PACKS}" STREQUAL "false")
     add_definitions("-DNO_ASSET_PACKS")

--- a/agdk/agdktunnel/app/src/main/cpp/CMakeLists.txt
+++ b/agdk/agdktunnel/app/src/main/cpp/CMakeLists.txt
@@ -109,7 +109,7 @@ add_library(${CMAKE_PROJECT_NAME} SHARED
      ui_scene.cpp
      util.cpp
      vertexbuf.cpp
-     vibration_manager.cpp
+     vibration_helper.cpp
      welcome_scene.cpp
      ${COMMON_SRC_DIR}/Versions.cpp
      )

--- a/agdk/agdktunnel/app/src/main/cpp/native_engine.cpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_engine.cpp
@@ -123,15 +123,15 @@ NativeEngine::NativeEngine(struct android_app *app) {
     mMemoryConsumer = new MemoryConsumer(false);
 
     // Initialize the GNI runtime. This function needs to be called before any
-    // call to the wrapper code (the Vibration Manager depends on this).
+    // call to the wrapper code (the VibrationHelper depends on this).
     GniCore_init(app->activity->vm, app->activity->javaGameActivity);
 
-    // Initialize the vibration manager, used to vibrate the device if supported
+    // Initialize the vibration helper, used to vibrate the device if supported
     String *vibratorString = String_fromCString(VIBRATOR_SYSTEM_STRING);
     String *vibrationManagerString = String_fromCString(VIBRATOR_MANAGER_SYSTEM_STRING);
-  mVibrationHelper = new VibrationHelper(app->activity->javaGameActivity,
-                                         String_getJniReference(vibratorString),
-                                         String_getJniReference(vibrationManagerString));
+    mVibrationHelper = new VibrationHelper(app->activity->javaGameActivity,
+                                           String_getJniReference(vibratorString),
+                                           String_getJniReference(vibrationManagerString));
     String_destroy(vibratorString);
     String_destroy(vibrationManagerString);
 

--- a/agdk/agdktunnel/app/src/main/cpp/native_engine.cpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_engine.cpp
@@ -129,9 +129,9 @@ NativeEngine::NativeEngine(struct android_app *app) {
     // Initialize the vibration manager, used to vibrate the device if supported
     String *vibratorString = String_fromCString(VIBRATOR_SYSTEM_STRING);
     String *vibrationManagerString = String_fromCString(VIBRATOR_MANAGER_SYSTEM_STRING);
-    mVibrationManager = new VibrationManager(app->activity->javaGameActivity,
-                                             String_getJniReference(vibratorString),
-                                             String_getJniReference(vibrationManagerString));
+  mVibrationHelper = new VibrationHelper(app->activity->javaGameActivity,
+                                         String_getJniReference(vibratorString),
+                                         String_getJniReference(vibrationManagerString));
     String_destroy(vibratorString);
     String_destroy(vibrationManagerString);
 
@@ -194,7 +194,7 @@ NativeEngine *NativeEngine::GetInstance() {
 
 NativeEngine::~NativeEngine() {
     VLOGD("NativeEngine: destructor running");
-    delete mVibrationManager;
+    delete mVibrationHelper;
     delete mTuningManager;
     Paddleboat_setControllerStatusCallback(NULL, NULL);
     Paddleboat_destroy(GetJniEnv());

--- a/agdk/agdktunnel/app/src/main/cpp/native_engine.hpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_engine.hpp
@@ -22,7 +22,9 @@
 #include "memory_consumer.hpp"
 #include "texture_manager.hpp"
 #include "tuning_manager.hpp"
+#include "vibration_manager.hpp"
 #include "data_loader_machine.hpp"
+#include "java/lang/string.h"
 
 struct NativeEngineSavedState {
     bool mHasFocus;
@@ -56,6 +58,9 @@ public:
     // returns the memory consumer instance
     MemoryConsumer *GetMemoryConsumer() { return mMemoryConsumer; }
 
+    // returns the vibration manager instance
+    VibrationManager *GetVibrationManager() { return mVibrationManager; }
+
     // returns the (singleton) instance
     static NativeEngine *GetInstance();
 
@@ -75,7 +80,12 @@ public:
 
     void SetInputSdkContext(int context);
 
-private:
+    enum SystemService {
+      eVibrator,
+      eVibrationManager
+    };
+
+ private:
     // variables to track Android lifecycle:
     bool mHasFocus, mIsVisible, mHasWindow;
 
@@ -123,6 +133,9 @@ private:
 
     // Memory consumer instance
     MemoryConsumer *mMemoryConsumer;
+
+    // Vibration manager instance
+    VibrationManager *mVibrationManager;
 
     // is this the first frame we're drawing?
     bool mIsFirstFrame;
@@ -177,6 +190,7 @@ private:
     }
 
 public:
+
     // these are public for simplicity because we have internal static callbacks
     void HandleCommand(int32_t cmd);
 

--- a/agdk/agdktunnel/app/src/main/cpp/native_engine.hpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_engine.hpp
@@ -58,8 +58,8 @@ public:
     // returns the memory consumer instance
     MemoryConsumer *GetMemoryConsumer() { return mMemoryConsumer; }
 
-    // returns the vibration manager instance
-    VibrationHelper *GetVibrationManager() { return mVibrationHelper; }
+    // returns the vibration helper instance
+    VibrationHelper *GetVibrationHelper() { return mVibrationHelper; }
 
     // returns the (singleton) instance
     static NativeEngine *GetInstance();

--- a/agdk/agdktunnel/app/src/main/cpp/native_engine.hpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_engine.hpp
@@ -22,7 +22,7 @@
 #include "memory_consumer.hpp"
 #include "texture_manager.hpp"
 #include "tuning_manager.hpp"
-#include "vibration_manager.hpp"
+#include "vibration_helper.hpp"
 #include "data_loader_machine.hpp"
 #include "java/lang/string.h"
 
@@ -59,7 +59,7 @@ public:
     MemoryConsumer *GetMemoryConsumer() { return mMemoryConsumer; }
 
     // returns the vibration manager instance
-    VibrationManager *GetVibrationManager() { return mVibrationManager; }
+    VibrationHelper *GetVibrationManager() { return mVibrationHelper; }
 
     // returns the (singleton) instance
     static NativeEngine *GetInstance();
@@ -134,8 +134,8 @@ public:
     // Memory consumer instance
     MemoryConsumer *mMemoryConsumer;
 
-    // Vibration manager instance
-    VibrationManager *mVibrationManager;
+    // Vibration helper instance
+    VibrationHelper *mVibrationHelper;
 
     // is this the first frame we're drawing?
     bool mIsFirstFrame;

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/content/context.cc
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/content/context.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#include "android/content/context.h"
+
+#include "android/content/context.hpp"
+
+Context* Context_wrapJniReference(jobject jobj) {
+  return reinterpret_cast<Context*>(new ::android::content::Context(jobj));
+}
+
+jobject Context_getJniReference(const Context* context) {
+  return reinterpret_cast<const ::android::content::Context*>(context)->GetImpl();
+}
+
+void Context_destroy(const Context* context) {
+  ::android::content::Context::destroy(reinterpret_cast<const ::android::content::Context*>(context));
+}
+
+Object* Context_getSystemService(const Context* context, String* name) {
+  return reinterpret_cast<Object*>(&reinterpret_cast<const ::android::content::Context*>(context)->getSystemService(*reinterpret_cast<const ::java::lang::String*>(name)));
+}

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/content/context.h
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/content/context.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#ifndef ANDROID_CONTENT_CONTEXT_H_
+#define ANDROID_CONTENT_CONTEXT_H_
+
+#include <cstdint>
+#include <jni.h>
+#include "java/lang/object.h"
+#include "java/lang/string.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct Context_ Context;
+
+/// Wraps a JNI reference with Context object.
+/// @param jobj A JNI reference to be wrapped with Context object.
+/// @see Context_destroy
+Context* Context_wrapJniReference(jobject jobj);
+
+jobject Context_getJniReference(const Context* context);
+
+/// Destroys context and all internal resources related to it. This function should be
+/// called when context is no longer needed.
+/// @param context An object to be destroyed.
+void Context_destroy(const Context* context);
+
+Object* Context_getSystemService(const Context* context, String* name);
+
+#ifdef __cplusplus
+};  // extern "C"
+#endif
+
+#endif  // ANDROID_CONTENT_CONTEXT_H_

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/os/vibration_attributes.cc
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/os/vibration_attributes.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#include "android/os/vibration_attributes.h"
+
+#include "android/os/vibration_attributes.hpp"
+
+VibrationAttributes* VibrationAttributes_wrapJniReference(jobject jobj) {
+  return reinterpret_cast<VibrationAttributes*>(new ::android::os::VibrationAttributes(jobj));
+}
+
+jobject VibrationAttributes_getJniReference(const VibrationAttributes* vibration_attributes) {
+  return reinterpret_cast<const ::android::os::VibrationAttributes*>(vibration_attributes)->GetImpl();
+}
+
+void VibrationAttributes_destroy(const VibrationAttributes* vibration_attributes) {
+  ::android::os::VibrationAttributes::destroy(reinterpret_cast<const ::android::os::VibrationAttributes*>(vibration_attributes));
+}
+
+VibrationAttributes* VibrationAttributes_createForUsage(int32_t usage) {
+  return reinterpret_cast<VibrationAttributes*>(&::android::os::VibrationAttributes::createForUsage(usage));
+}

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/os/vibration_attributes.h
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/os/vibration_attributes.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#ifndef ANDROID_OS_VIBRATIONATTRIBUTES_H_
+#define ANDROID_OS_VIBRATIONATTRIBUTES_H_
+
+#include <cstdint>
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct VibrationAttributes_ VibrationAttributes;
+
+/// Wraps a JNI reference with VibrationAttributes object.
+/// @param jobj A JNI reference to be wrapped with VibrationAttributes object.
+/// @see VibrationAttributes_destroy
+VibrationAttributes* VibrationAttributes_wrapJniReference(jobject jobj);
+
+jobject VibrationAttributes_getJniReference(const VibrationAttributes* vibration_attributes);
+
+/// Destroys vibration_attributes and all internal resources related to it. This function should be
+/// called when vibration_attributes is no longer needed.
+/// @param vibration_attributes An object to be destroyed.
+void VibrationAttributes_destroy(const VibrationAttributes* vibration_attributes);
+
+VibrationAttributes* VibrationAttributes_createForUsage(int32_t usage);
+
+#ifdef __cplusplus
+};  // extern "C"
+#endif
+
+#endif  // ANDROID_OS_VIBRATIONATTRIBUTES_H_

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/os/vibration_effect.cc
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/os/vibration_effect.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#include "android/os/vibration_effect.h"
+
+#include "android/os/vibration_effect.hpp"
+
+VibrationEffect* VibrationEffect_wrapJniReference(jobject jobj) {
+  return reinterpret_cast<VibrationEffect*>(new ::android::os::VibrationEffect(jobj));
+}
+
+jobject VibrationEffect_getJniReference(const VibrationEffect* vibration_effect) {
+  return reinterpret_cast<const ::android::os::VibrationEffect*>(vibration_effect)->GetImpl();
+}
+
+void VibrationEffect_destroy(const VibrationEffect* vibration_effect) {
+  ::android::os::VibrationEffect::destroy(reinterpret_cast<const ::android::os::VibrationEffect*>(vibration_effect));
+}
+
+VibrationEffect* VibrationEffect_createPredefined(int32_t effect_id) {
+  return reinterpret_cast<VibrationEffect*>(&::android::os::VibrationEffect::createPredefined(effect_id));
+}

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/os/vibration_effect.h
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/os/vibration_effect.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#ifndef ANDROID_OS_VIBRATIONEFFECT_H_
+#define ANDROID_OS_VIBRATIONEFFECT_H_
+
+#include <cstdint>
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct VibrationEffect_ VibrationEffect;
+
+/// Wraps a JNI reference with VibrationEffect object.
+/// @param jobj A JNI reference to be wrapped with VibrationEffect object.
+/// @see VibrationEffect_destroy
+VibrationEffect* VibrationEffect_wrapJniReference(jobject jobj);
+
+jobject VibrationEffect_getJniReference(const VibrationEffect* vibration_effect);
+
+/// Destroys vibration_effect and all internal resources related to it. This function should be
+/// called when vibration_effect is no longer needed.
+/// @param vibration_effect An object to be destroyed.
+void VibrationEffect_destroy(const VibrationEffect* vibration_effect);
+
+VibrationEffect* VibrationEffect_createPredefined(int32_t effect_id);
+
+#ifdef __cplusplus
+};  // extern "C"
+#endif
+
+#endif  // ANDROID_OS_VIBRATIONEFFECT_H_

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/os/vibrator.cc
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/os/vibrator.cc
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#include "android/os/vibrator.h"
+
+#include "android/os/vibrator.hpp"
+
+Vibrator* Vibrator_wrapJniReference(jobject jobj) {
+  return reinterpret_cast<Vibrator*>(new ::android::os::Vibrator(jobj));
+}
+
+jobject Vibrator_getJniReference(const Vibrator* vibrator) {
+  return reinterpret_cast<const ::android::os::Vibrator*>(vibrator)->GetImpl();
+}
+
+void Vibrator_destroy(const Vibrator* vibrator) {
+  ::android::os::Vibrator::destroy(reinterpret_cast<const ::android::os::Vibrator*>(vibrator));
+}
+
+void Vibrator_cancel(const Vibrator* vibrator) {
+  reinterpret_cast<const ::android::os::Vibrator*>(vibrator)->cancel();
+}
+
+bool Vibrator_hasVibrator(const Vibrator* vibrator) {
+  return reinterpret_cast<const ::android::os::Vibrator*>(vibrator)->hasVibrator();
+}
+
+void Vibrator_vibrate(const Vibrator* vibrator, int64_t milliseconds) {
+  reinterpret_cast<const ::android::os::Vibrator*>(vibrator)->vibrate(milliseconds);
+}

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/os/vibrator.h
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/os/vibrator.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#ifndef ANDROID_OS_VIBRATOR_H_
+#define ANDROID_OS_VIBRATOR_H_
+
+#include <cstdint>
+#include <jni.h>
+#include "android/os/vibration_attributes.h"
+#include "android/os/vibration_effect.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct Vibrator_ Vibrator;
+
+/// Wraps a JNI reference with Vibrator object.
+/// @param jobj A JNI reference to be wrapped with Vibrator object.
+/// @see Vibrator_destroy
+Vibrator* Vibrator_wrapJniReference(jobject jobj);
+
+jobject Vibrator_getJniReference(const Vibrator* vibrator);
+
+/// Destroys vibrator and all internal resources related to it. This function should be
+/// called when vibrator is no longer needed.
+/// @param vibrator An object to be destroyed.
+void Vibrator_destroy(const Vibrator* vibrator);
+
+void Vibrator_cancel(const Vibrator* vibrator);
+
+bool Vibrator_hasVibrator(const Vibrator* vibrator);
+
+void Vibrator_vibrate(const Vibrator* vibrator, int64_t milliseconds);
+
+#ifdef __cplusplus
+};  // extern "C"
+#endif
+
+#endif  // ANDROID_OS_VIBRATOR_H_

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/os/vibrator_manager.cc
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/os/vibrator_manager.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#include "android/os/vibrator_manager.h"
+
+#include "android/os/vibrator_manager.hpp"
+
+VibratorManager* VibratorManager_wrapJniReference(jobject jobj) {
+  return reinterpret_cast<VibratorManager*>(new ::android::os::VibratorManager(jobj));
+}
+
+jobject VibratorManager_getJniReference(const VibratorManager* vibrator_manager) {
+  return reinterpret_cast<const ::android::os::VibratorManager*>(vibrator_manager)->GetImpl();
+}
+
+void VibratorManager_destroy(const VibratorManager* vibrator_manager) {
+  ::android::os::VibratorManager::destroy(reinterpret_cast<const ::android::os::VibratorManager*>(vibrator_manager));
+}
+
+Vibrator* VibratorManager_getDefaultVibrator(const VibratorManager* vibrator_manager) {
+  return reinterpret_cast<Vibrator*>(&reinterpret_cast<const ::android::os::VibratorManager*>(vibrator_manager)->getDefaultVibrator());
+}

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/os/vibrator_manager.h
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/android/os/vibrator_manager.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#ifndef ANDROID_OS_VIBRATORMANAGER_H_
+#define ANDROID_OS_VIBRATORMANAGER_H_
+
+#include <cstdint>
+#include <jni.h>
+#include "android/os/vibrator.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct VibratorManager_ VibratorManager;
+
+/// Wraps a JNI reference with VibratorManager object.
+/// @param jobj A JNI reference to be wrapped with VibratorManager object.
+/// @see VibratorManager_destroy
+VibratorManager* VibratorManager_wrapJniReference(jobject jobj);
+
+jobject VibratorManager_getJniReference(const VibratorManager* vibrator_manager);
+
+/// Destroys vibrator_manager and all internal resources related to it. This function should be
+/// called when vibrator_manager is no longer needed.
+/// @param vibrator_manager An object to be destroyed.
+void VibratorManager_destroy(const VibratorManager* vibrator_manager);
+
+Vibrator* VibratorManager_getDefaultVibrator(const VibratorManager* vibrator_manager);
+
+#ifdef __cplusplus
+};  // extern "C"
+#endif
+
+#endif  // ANDROID_OS_VIBRATORMANAGER_H_

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/java/lang/char_sequence.cc
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/java/lang/char_sequence.cc
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#include "java/lang/char_sequence.h"
+
+#include "java/lang/char_sequence.hpp"
+
+CharSequence* CharSequence_wrapJniReference(jobject jobj) {
+  return reinterpret_cast<CharSequence*>(new ::java::lang::CharSequence(jobj));
+}
+
+jobject CharSequence_getJniReference(const CharSequence* char_sequence) {
+  return reinterpret_cast<const ::java::lang::CharSequence*>(char_sequence)->GetImpl();
+}
+
+void CharSequence_destroy(const CharSequence* char_sequence) {
+  ::java::lang::CharSequence::destroy(reinterpret_cast<const ::java::lang::CharSequence*>(char_sequence));
+}

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/java/lang/char_sequence.h
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/java/lang/char_sequence.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#ifndef JAVA_LANG_CHARSEQUENCE_H_
+#define JAVA_LANG_CHARSEQUENCE_H_
+
+#include <cstdint>
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct CharSequence_ CharSequence;
+
+/// Wraps a JNI reference with CharSequence object.
+/// @param jobj A JNI reference to be wrapped with CharSequence object.
+/// @see CharSequence_destroy
+CharSequence* CharSequence_wrapJniReference(jobject jobj);
+
+jobject CharSequence_getJniReference(const CharSequence* char_sequence);
+
+/// Destroys char_sequence and all internal resources related to it. This function should be
+/// called when char_sequence is no longer needed.
+/// @param char_sequence An object to be destroyed.
+void CharSequence_destroy(const CharSequence* char_sequence);
+
+#ifdef __cplusplus
+};  // extern "C"
+#endif
+
+#endif  // JAVA_LANG_CHARSEQUENCE_H_

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/java/lang/object.cc
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/java/lang/object.cc
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#include "java/lang/object.h"
+
+#include "java/lang/object.hpp"
+
+Object* Object_wrapJniReference(jobject jobj) {
+  return reinterpret_cast<Object*>(new ::java::lang::Object(jobj));
+}
+
+jobject Object_getJniReference(const Object* object) {
+  return reinterpret_cast<const ::java::lang::Object*>(object)->GetImpl();
+}
+
+void Object_destroy(const Object* object) {
+  ::java::lang::Object::destroy(reinterpret_cast<const ::java::lang::Object*>(object));
+}
+
+String* Object_toString(const Object* object) {
+  return reinterpret_cast<String*>(&reinterpret_cast<const ::java::lang::Object*>(object)->toString());
+}

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/java/lang/object.h
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/java/lang/object.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#ifndef JAVA_LANG_OBJECT_H_
+#define JAVA_LANG_OBJECT_H_
+
+#include <cstdint>
+#include <jni.h>
+#include "java/lang/string.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct Object_ Object;
+
+/// Wraps a JNI reference with Object object.
+/// @param jobj A JNI reference to be wrapped with Object object.
+/// @see Object_destroy
+Object* Object_wrapJniReference(jobject jobj);
+
+jobject Object_getJniReference(const Object* object);
+
+/// Destroys object and all internal resources related to it. This function should be
+/// called when object is no longer needed.
+/// @param object An object to be destroyed.
+void Object_destroy(const Object* object);
+
+String* Object_toString(const Object* object);
+
+#ifdef __cplusplus
+};  // extern "C"
+#endif
+
+#endif  // JAVA_LANG_OBJECT_H_

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/java/lang/string.cc
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/java/lang/string.cc
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#include "java/lang/string.h"
+
+#include "java/lang/string.hpp"
+
+String* String_fromCString(const char* c_string) {
+  return String_wrapJniReference(gni::GniCore::GetInstance()->ConvertString(c_string).GetImpl());
+}
+
+const char* String_toCString(String* string) {
+  return gni::GniCore::GetInstance()->ConvertString(String_getJniReference(string));
+}
+
+void String_destroyCString(const char* c_string) {
+  free(const_cast<char*>(c_string));
+}
+
+String* String_wrapJniReference(jobject jobj) {
+  return reinterpret_cast<String*>(new ::java::lang::String(jobj));
+}
+
+jobject String_getJniReference(const String* string) {
+  return reinterpret_cast<const ::java::lang::String*>(string)->GetImpl();
+}
+
+void String_destroy(const String* string) {
+  ::java::lang::String::destroy(reinterpret_cast<const ::java::lang::String*>(string));
+}

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/java/lang/string.h
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/c/java/lang/string.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#ifndef JAVA_LANG_STRING_H_
+#define JAVA_LANG_STRING_H_
+
+#include <cstdint>
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct String_ String;
+
+String* String_fromCString(const char* c_string);
+const char* String_toCString(String* string);
+void String_destroyCString(const char* c_string);
+
+/// Wraps a JNI reference with String object.
+/// @param jobj A JNI reference to be wrapped with String object.
+/// @see String_destroy
+String* String_wrapJniReference(jobject jobj);
+
+jobject String_getJniReference(const String* string);
+
+/// Destroys string and all internal resources related to it. This function should be
+/// called when string is no longer needed.
+/// @param string An object to be destroyed.
+void String_destroy(const String* string);
+
+#ifdef __cplusplus
+};  // extern "C"
+#endif
+
+#endif  // JAVA_LANG_STRING_H_

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/content/context.cpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/content/context.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#include "android/content/context.hpp"
+#include <memory>
+#include "gni/common/scoped_local_ref.h"
+#include "gni/gni.hpp"
+#include "gni/object.hpp"
+#include "java/lang/object.hpp"
+#include "java/lang/string.hpp"
+
+namespace android {
+namespace content {
+
+jclass Context::GetClass()
+{
+  static const jclass cached_class = gni::GniCore::GetInstance()->GetClassGlobalRef("android/content/Context");
+  return cached_class;
+}
+
+void Context::destroy(const Context* object)
+{
+  delete object;
+}
+
+::java::lang::Object& Context::getSystemService(const ::java::lang::String& name) const
+{
+  JNIEnv *env = gni::GniCore::GetInstance()->GetJniEnv();
+  static const jmethodID method_id = env->GetMethodID(GetClass(), "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;");
+  ::java::lang::Object* ret = new ::java::lang::Object(gni::common::ScopedLocalRef<jobject>(env, env->CallObjectMethod(GetImpl(), method_id, name.GetImpl())).Get());
+  return *ret;
+}
+
+}  // namespace content
+}  // namespace android
+

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/content/context.hpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/content/context.hpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#ifndef CPP_ANDROID_CONTENT_CONTEXT
+#define CPP_ANDROID_CONTENT_CONTEXT
+
+#include <memory>
+#include "gni/common/scoped_local_ref.h"
+#include "gni/gni.hpp"
+#include "gni/object.hpp"
+#include "java/lang/object.hpp"
+#include "java/lang/string.hpp"
+
+namespace android {
+namespace content {
+
+class Context : virtual public ::gni::Object
+{
+public:
+    static jclass GetClass();
+    static void destroy(const Context* object);
+    explicit Context(jobject object) : ::gni::Object(object) {}
+    ~Context() override = default;
+    virtual ::java::lang::Object& getSystemService(const ::java::lang::String& name) const;
+};
+
+}  // namespace content
+}  // namespace android
+
+#endif  // CPP_ANDROID_CONTENT_CONTEXT
+

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/os/vibration_attributes.cpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/os/vibration_attributes.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#include "android/os/vibration_attributes.hpp"
+#include <memory>
+#include "gni/common/scoped_local_ref.h"
+#include "gni/gni.hpp"
+#include "gni/object.hpp"
+
+namespace android {
+namespace os {
+
+jclass VibrationAttributes::GetClass()
+{
+  static const jclass cached_class = gni::GniCore::GetInstance()->GetClassGlobalRef("android/os/VibrationAttributes");
+  return cached_class;
+}
+
+void VibrationAttributes::destroy(const VibrationAttributes* object)
+{
+  delete object;
+}
+
+::android::os::VibrationAttributes& VibrationAttributes::createForUsage(int32_t usage)
+{
+  JNIEnv *env = gni::GniCore::GetInstance()->GetJniEnv();
+  static const jmethodID method_id = env->GetStaticMethodID(GetClass(), "createForUsage", "(I)Landroid/os/VibrationAttributes;");
+  ::android::os::VibrationAttributes* ret = new ::android::os::VibrationAttributes(gni::common::ScopedLocalRef<jobject>(env, env->CallStaticObjectMethod(GetClass(), method_id, usage)).Get());
+  return *ret;
+}
+
+}  // namespace os
+}  // namespace android
+

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/os/vibration_attributes.hpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/os/vibration_attributes.hpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#ifndef CPP_ANDROID_OS_VIBRATIONATTRIBUTES
+#define CPP_ANDROID_OS_VIBRATIONATTRIBUTES
+
+#include <memory>
+#include "gni/common/scoped_local_ref.h"
+#include "gni/gni.hpp"
+#include "gni/object.hpp"
+
+namespace android {
+namespace os {
+
+class VibrationAttributes : virtual public ::gni::Object
+{
+public:
+    static jclass GetClass();
+    static void destroy(const VibrationAttributes* object);
+    explicit VibrationAttributes(jobject object) : ::gni::Object(object) {}
+    ~VibrationAttributes() override = default;
+    static ::android::os::VibrationAttributes& createForUsage(int32_t usage);
+};
+
+}  // namespace os
+}  // namespace android
+
+#endif  // CPP_ANDROID_OS_VIBRATIONATTRIBUTES
+

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/os/vibration_effect.cpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/os/vibration_effect.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#include "android/os/vibration_effect.hpp"
+#include <memory>
+#include "gni/common/scoped_local_ref.h"
+#include "gni/gni.hpp"
+#include "gni/object.hpp"
+
+namespace android {
+namespace os {
+
+jclass VibrationEffect::GetClass()
+{
+  static const jclass cached_class = gni::GniCore::GetInstance()->GetClassGlobalRef("android/os/VibrationEffect");
+  return cached_class;
+}
+
+void VibrationEffect::destroy(const VibrationEffect* object)
+{
+  delete object;
+}
+
+::android::os::VibrationEffect& VibrationEffect::createPredefined(int32_t effectId)
+{
+  JNIEnv *env = gni::GniCore::GetInstance()->GetJniEnv();
+  static const jmethodID method_id = env->GetStaticMethodID(GetClass(), "createPredefined", "(I)Landroid/os/VibrationEffect;");
+  ::android::os::VibrationEffect* ret = new ::android::os::VibrationEffect(gni::common::ScopedLocalRef<jobject>(env, env->CallStaticObjectMethod(GetClass(), method_id, effectId)).Get());
+  return *ret;
+}
+
+}  // namespace os
+}  // namespace android
+

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/os/vibration_effect.hpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/os/vibration_effect.hpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#ifndef CPP_ANDROID_OS_VIBRATIONEFFECT
+#define CPP_ANDROID_OS_VIBRATIONEFFECT
+
+#include <memory>
+#include "gni/common/scoped_local_ref.h"
+#include "gni/gni.hpp"
+#include "gni/object.hpp"
+
+namespace android {
+namespace os {
+
+class VibrationEffect : virtual public ::gni::Object
+{
+public:
+    static jclass GetClass();
+    static void destroy(const VibrationEffect* object);
+    explicit VibrationEffect(jobject object) : ::gni::Object(object) {}
+    ~VibrationEffect() override = default;
+    static ::android::os::VibrationEffect& createPredefined(int32_t effectId);
+};
+
+}  // namespace os
+}  // namespace android
+
+#endif  // CPP_ANDROID_OS_VIBRATIONEFFECT
+

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/os/vibrator.cpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/os/vibrator.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#include "android/os/vibrator.hpp"
+#include <memory>
+#include "android/os/vibration_attributes.hpp"
+#include "android/os/vibration_effect.hpp"
+#include "gni/common/scoped_local_ref.h"
+#include "gni/gni.hpp"
+#include "gni/object.hpp"
+
+namespace android {
+namespace os {
+
+jclass Vibrator::GetClass()
+{
+  static const jclass cached_class = gni::GniCore::GetInstance()->GetClassGlobalRef("android/os/Vibrator");
+  return cached_class;
+}
+
+void Vibrator::destroy(const Vibrator* object)
+{
+  delete object;
+}
+
+void Vibrator::cancel() const
+{
+  JNIEnv *env = gni::GniCore::GetInstance()->GetJniEnv();
+  static const jmethodID method_id = env->GetMethodID(GetClass(), "cancel", "()V");
+  env->CallVoidMethod(GetImpl(), method_id);
+}
+
+bool Vibrator::hasVibrator() const
+{
+  JNIEnv *env = gni::GniCore::GetInstance()->GetJniEnv();
+  static const jmethodID method_id = env->GetMethodID(GetClass(), "hasVibrator", "()Z");
+  bool ret = env->CallBooleanMethod(GetImpl(), method_id);
+  return ret;
+}
+
+void Vibrator::vibrate(int64_t milliseconds) const
+{
+  JNIEnv *env = gni::GniCore::GetInstance()->GetJniEnv();
+  static const jmethodID method_id = env->GetMethodID(GetClass(), "vibrate", "(J)V");
+  env->CallVoidMethod(GetImpl(), method_id, milliseconds);
+}
+
+void Vibrator::vibrate(const ::android::os::VibrationEffect& vibe) const
+{
+  JNIEnv *env = gni::GniCore::GetInstance()->GetJniEnv();
+  static const jmethodID method_id = env->GetMethodID(GetClass(), "vibrate", "(Landroid/os/VibrationEffect;)V");
+  env->CallVoidMethod(GetImpl(), method_id, vibe.GetImpl());
+}
+
+void Vibrator::vibrate(const ::android::os::VibrationEffect& vibe, const ::android::os::VibrationAttributes& attributes) const
+{
+  JNIEnv *env = gni::GniCore::GetInstance()->GetJniEnv();
+  static const jmethodID method_id = env->GetMethodID(GetClass(), "vibrate", "(Landroid/os/VibrationEffect;Landroid/os/VibrationAttributes;)V");
+  env->CallVoidMethod(GetImpl(), method_id, vibe.GetImpl(), attributes.GetImpl());
+}
+
+}  // namespace os
+}  // namespace android
+

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/os/vibrator.hpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/os/vibrator.hpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#ifndef CPP_ANDROID_OS_VIBRATOR
+#define CPP_ANDROID_OS_VIBRATOR
+
+#include <memory>
+#include "android/os/vibration_attributes.hpp"
+#include "android/os/vibration_effect.hpp"
+#include "gni/common/scoped_local_ref.h"
+#include "gni/gni.hpp"
+#include "gni/object.hpp"
+
+namespace android {
+namespace os {
+
+class Vibrator : virtual public ::gni::Object
+{
+public:
+    static jclass GetClass();
+    static void destroy(const Vibrator* object);
+    explicit Vibrator(jobject object) : ::gni::Object(object) {}
+    ~Vibrator() override = default;
+    virtual void cancel() const;
+    virtual bool hasVibrator() const;
+    virtual void vibrate(int64_t milliseconds) const;
+    virtual void vibrate(const ::android::os::VibrationEffect& vibe) const;
+    virtual void vibrate(const ::android::os::VibrationEffect& vibe, const ::android::os::VibrationAttributes& attributes) const;
+};
+
+}  // namespace os
+}  // namespace android
+
+#endif  // CPP_ANDROID_OS_VIBRATOR
+

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/os/vibrator_manager.cpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/os/vibrator_manager.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#include "android/os/vibrator_manager.hpp"
+#include <memory>
+#include "android/os/vibrator.hpp"
+#include "gni/common/scoped_local_ref.h"
+#include "gni/gni.hpp"
+#include "gni/object.hpp"
+
+namespace android {
+namespace os {
+
+jclass VibratorManager::GetClass()
+{
+  static const jclass cached_class = gni::GniCore::GetInstance()->GetClassGlobalRef("android/os/VibratorManager");
+  return cached_class;
+}
+
+void VibratorManager::destroy(const VibratorManager* object)
+{
+  delete object;
+}
+
+::android::os::Vibrator& VibratorManager::getDefaultVibrator() const
+{
+  JNIEnv *env = gni::GniCore::GetInstance()->GetJniEnv();
+  static const jmethodID method_id = env->GetMethodID(GetClass(), "getDefaultVibrator", "()Landroid/os/Vibrator;");
+  ::android::os::Vibrator* ret = new ::android::os::Vibrator(gni::common::ScopedLocalRef<jobject>(env, env->CallObjectMethod(GetImpl(), method_id)).Get());
+  return *ret;
+}
+
+}  // namespace os
+}  // namespace android
+

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/os/vibrator_manager.hpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/android/os/vibrator_manager.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#ifndef CPP_ANDROID_OS_VIBRATORMANAGER
+#define CPP_ANDROID_OS_VIBRATORMANAGER
+
+#include <memory>
+#include "android/os/vibrator.hpp"
+#include "gni/common/scoped_local_ref.h"
+#include "gni/gni.hpp"
+#include "gni/object.hpp"
+
+namespace android {
+namespace os {
+
+class VibratorManager : virtual public ::gni::Object
+{
+public:
+    static jclass GetClass();
+    static void destroy(const VibratorManager* object);
+    explicit VibratorManager(jobject object) : ::gni::Object(object) {}
+    ~VibratorManager() override = default;
+    virtual ::android::os::Vibrator& getDefaultVibrator() const;
+};
+
+}  // namespace os
+}  // namespace android
+
+#endif  // CPP_ANDROID_OS_VIBRATORMANAGER
+

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/java/lang/char_sequence.cpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/java/lang/char_sequence.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#include "java/lang/char_sequence.hpp"
+#include <memory>
+#include "gni/common/scoped_local_ref.h"
+#include "gni/gni.hpp"
+#include "gni/object.hpp"
+
+namespace java {
+namespace lang {
+
+jclass CharSequence::GetClass()
+{
+  static const jclass cached_class = gni::GniCore::GetInstance()->GetClassGlobalRef("java/lang/CharSequence");
+  return cached_class;
+}
+
+void CharSequence::destroy(const CharSequence* object)
+{
+  delete object;
+}
+
+}  // namespace lang
+}  // namespace java
+

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/java/lang/char_sequence.hpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/java/lang/char_sequence.hpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#ifndef CPP_JAVA_LANG_CHARSEQUENCE
+#define CPP_JAVA_LANG_CHARSEQUENCE
+
+#include <memory>
+#include "gni/common/scoped_local_ref.h"
+#include "gni/gni.hpp"
+#include "gni/object.hpp"
+
+namespace java {
+namespace lang {
+
+class CharSequence : virtual public ::gni::Object
+{
+public:
+    static jclass GetClass();
+    static void destroy(const CharSequence* object);
+    explicit CharSequence(jobject object) : ::gni::Object(object) {}
+    ~CharSequence() override = default;
+};
+
+}  // namespace lang
+}  // namespace java
+
+#endif  // CPP_JAVA_LANG_CHARSEQUENCE
+

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/java/lang/object.cpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/java/lang/object.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#include "java/lang/object.hpp"
+#include <memory>
+#include "gni/common/scoped_local_ref.h"
+#include "gni/gni.hpp"
+#include "gni/object.hpp"
+#include "java/lang/string.hpp"
+
+namespace java {
+namespace lang {
+
+jclass Object::GetClass()
+{
+  static const jclass cached_class = gni::GniCore::GetInstance()->GetClassGlobalRef("java/lang/Object");
+  return cached_class;
+}
+
+void Object::destroy(const Object* object)
+{
+  delete object;
+}
+
+::java::lang::String& Object::toString() const
+{
+  JNIEnv *env = gni::GniCore::GetInstance()->GetJniEnv();
+  static const jmethodID method_id = env->GetMethodID(GetClass(), "toString", "()Ljava/lang/String;");
+  ::java::lang::String* ret = new ::java::lang::String(gni::common::ScopedLocalRef<jobject>(env, env->CallObjectMethod(GetImpl(), method_id)).Get());
+  return *ret;
+}
+
+}  // namespace lang
+}  // namespace java
+

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/java/lang/object.hpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/java/lang/object.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#ifndef CPP_JAVA_LANG_OBJECT
+#define CPP_JAVA_LANG_OBJECT
+
+#include <memory>
+#include "gni/common/scoped_local_ref.h"
+#include "gni/gni.hpp"
+#include "gni/object.hpp"
+#include "java/lang/string.hpp"
+
+namespace java {
+namespace lang {
+
+class Object : virtual public ::gni::Object
+{
+public:
+    static jclass GetClass();
+    static void destroy(const Object* object);
+    explicit Object(jobject object) : ::gni::Object(object) {}
+    ~Object() override = default;
+    virtual ::java::lang::String& toString() const;
+};
+
+}  // namespace lang
+}  // namespace java
+
+#endif  // CPP_JAVA_LANG_OBJECT
+

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/java/lang/string.cpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/java/lang/string.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#include "java/lang/string.hpp"
+#include <memory>
+#include "gni/common/scoped_local_ref.h"
+#include "gni/gni.hpp"
+#include "gni/object.hpp"
+
+namespace java {
+namespace lang {
+
+jclass String::GetClass()
+{
+  static const jclass cached_class = gni::GniCore::GetInstance()->GetClassGlobalRef("java/lang/String");
+  return cached_class;
+}
+
+void String::destroy(const String* object)
+{
+  delete object;
+}
+
+}  // namespace lang
+}  // namespace java
+

--- a/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/java/lang/string.hpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_wrappers/cpp/java/lang/string.hpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was generated using the Library Wrapper tool
+// https://developer.android.com/games/develop/custom/wrapper
+
+#ifndef CPP_JAVA_LANG_STRING
+#define CPP_JAVA_LANG_STRING
+
+#include <memory>
+#include "gni/common/scoped_local_ref.h"
+#include "gni/gni.hpp"
+#include "gni/object.hpp"
+
+namespace java {
+namespace lang {
+
+class String : virtual public ::gni::Object
+{
+public:
+    static jclass GetClass();
+    static void destroy(const String* object);
+    explicit String(jobject object) : ::gni::Object(object) {}
+    ~String() override = default;
+};
+
+}  // namespace lang
+}  // namespace java
+
+#endif  // CPP_JAVA_LANG_STRING
+

--- a/agdk/agdktunnel/app/src/main/cpp/play_scene.cpp
+++ b/agdk/agdktunnel/app/src/main/cpp/play_scene.cpp
@@ -661,7 +661,7 @@ void PlayScene::DetectCollisions(float previousY) {
     int row = o->GetRowAt(mPlayerPos.z);
 
     if (o->grid[col][row]) {
-        VibrationManager *vibrationManager = NativeEngine::GetInstance()->GetVibrationManager();
+        VibrationHelper *vibrationManager = NativeEngine::GetInstance()->GetVibrationManager();
         if (vibrationManager->HasVibrator()) {
             vibrationManager->DoVibrateEffect();
         }

--- a/agdk/agdktunnel/app/src/main/cpp/play_scene.cpp
+++ b/agdk/agdktunnel/app/src/main/cpp/play_scene.cpp
@@ -661,10 +661,7 @@ void PlayScene::DetectCollisions(float previousY) {
     int row = o->GetRowAt(mPlayerPos.z);
 
     if (o->grid[col][row]) {
-        VibrationHelper *vibrationManager = NativeEngine::GetInstance()->GetVibrationManager();
-        if (vibrationManager->HasVibrator()) {
-            vibrationManager->DoVibrateEffect();
-        }
+        NativeEngine::GetInstance()->GetVibrationHelper()->DoVibrateEffect();
 #ifndef GOD_MODE
         // crashed against obstacle
         mLives--;

--- a/agdk/agdktunnel/app/src/main/cpp/play_scene.cpp
+++ b/agdk/agdktunnel/app/src/main/cpp/play_scene.cpp
@@ -661,6 +661,10 @@ void PlayScene::DetectCollisions(float previousY) {
     int row = o->GetRowAt(mPlayerPos.z);
 
     if (o->grid[col][row]) {
+        VibrationManager *vibrationManager = NativeEngine::GetInstance()->GetVibrationManager();
+        if (vibrationManager->HasVibrator()) {
+            vibrationManager->DoVibrateEffect();
+        }
 #ifndef GOD_MODE
         // crashed against obstacle
         mLives--;

--- a/agdk/agdktunnel/app/src/main/cpp/vibration_helper.cpp
+++ b/agdk/agdktunnel/app/src/main/cpp/vibration_helper.cpp
@@ -24,7 +24,7 @@
 // Add a VibrationAttribute to the vibrate call on API 33 or higher
 #define USE_VIBRATION_ATTRIBUTE_API_LEVEL 33
 
-// Use VibrationHelper to obtain a vibrator on API 31 and higher
+// Use VibrationManager to obtain a vibrator on API 31 and higher
 #define USE_VIBRATION_MANAGER_API_LEVEL 31
 
 // Use the VibrationEffect version of the vibrate call on API 26 or higher

--- a/agdk/agdktunnel/app/src/main/cpp/vibration_helper.hpp
+++ b/agdk/agdktunnel/app/src/main/cpp/vibration_helper.hpp
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-#ifndef agdktunnel_vibration_manager_hpp
-#define agdktunnel_vibration_manager_hpp
+#ifndef agdktunnel_vibration_helper_hpp
+#define agdktunnel_vibration_helper_hpp
 
 #include "android/os/vibrator.hpp"
 #include "android/os/vibration_attributes.hpp"
 #include "android/os/vibration_effect.hpp"
 
-class VibrationManager {
+class VibrationHelper {
  public:
-  VibrationManager(jobject mainActivity, jobject vibratorString, jobject vibrationManagerString);
-  ~VibrationManager();
+  VibrationHelper(jobject mainActivity, jobject vibratorString, jobject vibrationManagerString);
+  ~VibrationHelper();
 
   bool HasVibrator() const { return mHasVibrator; }
 
@@ -37,4 +37,4 @@ class VibrationManager {
   bool mHasVibrator;
 };
 
-#endif // agdktunnel_vibration_manager_hpp
+#endif // agdktunnel_vibration_helper_hpp

--- a/agdk/agdktunnel/app/src/main/cpp/vibration_helper.hpp
+++ b/agdk/agdktunnel/app/src/main/cpp/vibration_helper.hpp
@@ -26,8 +26,6 @@ class VibrationHelper {
   VibrationHelper(jobject mainActivity, jobject vibratorString, jobject vibrationManagerString);
   ~VibrationHelper();
 
-  bool HasVibrator() const { return mHasVibrator; }
-
   void DoVibrateEffect();
 
  private:

--- a/agdk/agdktunnel/app/src/main/cpp/vibration_manager.cpp
+++ b/agdk/agdktunnel/app/src/main/cpp/vibration_manager.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vibration_manager.hpp"
+#include "android/content/context.hpp"
+#include "android/os/vibrator_manager.hpp"
+#include <android/api-level.h>
+#include <gni/gni.h>
+#include <jni.h>
+
+// Add a VibrationAttribute to the vibrate call on API 33 or higher
+#define USE_VIBRATION_ATTRIBUTE_API_LEVEL 33
+
+// Use VibrationManager to obtain a vibrator on API 31 and higher
+#define USE_VIBRATION_MANAGER_API_LEVEL 31
+
+// Use the VibrationEffect version of the vibrate call on API 26 or higher
+#define USE_VIBRATION_EFFECT_API_LEVEL 26
+
+// android.os.VibrationAttributes.USAGE_CLASS_FEEDBACK
+#define USAGE_CLASS_FEEDBACK 2
+
+// android.os.VibrationEffect.EFFECT_HEAVY_CLICK
+#define EFFECT_HEAVY_CLICK 5
+
+// Amount of time to vibrate in milliseconds using the legacy vibrate method
+#define VIBRATION_TIME_MILLISECONDS 500
+
+VibrationManager::VibrationManager(jobject mainActivity, jobject vibratorString,
+                                   jobject vibrationManagerString) {
+  mHasVibrator = false;
+  mVibrator = NULL;
+  mVibrationAttributes = NULL;
+  mVibrationEffect = NULL;
+
+  // We need to create a Vibrator. Depending on the version of Android, we either
+  // do this directly from getSystemService, or use getSystemService to retrieve
+  // the VibratorManager, and use VibratorManager to get the default Vibrator
+  android::content::Context context(mainActivity);
+
+  int apiLevel = android_get_device_api_level();
+  if (apiLevel >= USE_VIBRATION_MANAGER_API_LEVEL) {
+    java::lang::String systemServiceName(vibrationManagerString);
+    java::lang::Object& vibratorManagerAsObject = context.getSystemService(systemServiceName);
+    android::os::VibratorManager vibratorManager(vibratorManagerAsObject.GetImpl());
+    mVibrator = &vibratorManager.getDefaultVibrator(); //new android::os::Vibrator(vibratorManager.getDefaultVibrator());
+  } else {
+    java::lang::String systemServiceName(vibratorString);
+    java::lang::Object& vibratorAsObject = context.getSystemService(systemServiceName);
+    mVibrator = reinterpret_cast<android::os::Vibrator*>(&vibratorAsObject);
+  }
+
+  if (mVibrator != NULL) {
+    // Check if we actually have a vibrator on this device
+    mHasVibrator = mVibrator->hasVibrator();
+    if (mHasVibrator) {
+      // There are a couple different ways to call vibrate on a vibrator. Depending on the
+      // version of Android, some may have been deprecated. We pick the appropriate
+      // combination based on API level
+      if (apiLevel >= USE_VIBRATION_ATTRIBUTE_API_LEVEL) {
+        const int32_t usage = USAGE_CLASS_FEEDBACK;
+        mVibrationAttributes = &android::os::VibrationAttributes::createForUsage(
+            usage);
+      }
+      if (apiLevel >- USE_VIBRATION_EFFECT_API_LEVEL) {
+        const int32_t effect = EFFECT_HEAVY_CLICK;
+        mVibrationEffect = &android::os::VibrationEffect::createPredefined(effect);
+      }
+    }
+  }
+}
+
+VibrationManager::~VibrationManager() {
+  if (mVibrationEffect != NULL) {
+    delete(mVibrationEffect);
+  }
+  if (mVibrationAttributes != NULL) {
+    delete(mVibrationAttributes);
+  }
+  if (mVibrator != NULL) {
+    delete mVibrator;
+  }
+}
+
+void VibrationManager::DoVibrateEffect() {
+  if (mVibrator != NULL && mHasVibrator) {
+    if (mVibrationEffect != NULL && mVibrationAttributes != NULL) {
+      mVibrator->vibrate(*mVibrationEffect, *mVibrationAttributes);
+    } else if (mVibrationEffect != NULL) {
+      mVibrator->vibrate(*mVibrationEffect);
+    } else {
+      const int64_t duration = VIBRATION_TIME_MILLISECONDS;
+      mVibrator->vibrate(duration);
+    }
+  }
+}

--- a/agdk/agdktunnel/app/src/main/cpp/vibration_manager.hpp
+++ b/agdk/agdktunnel/app/src/main/cpp/vibration_manager.hpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef agdktunnel_vibration_manager_hpp
+#define agdktunnel_vibration_manager_hpp
+
+#include "android/os/vibrator.hpp"
+#include "android/os/vibration_attributes.hpp"
+#include "android/os/vibration_effect.hpp"
+
+class VibrationManager {
+ public:
+  VibrationManager(jobject mainActivity, jobject vibratorString, jobject vibrationManagerString);
+  ~VibrationManager();
+
+  bool HasVibrator() const { return mHasVibrator; }
+
+  void DoVibrateEffect();
+
+ private:
+  android::os::Vibrator *mVibrator;
+  android::os::VibrationAttributes *mVibrationAttributes;
+  android::os::VibrationEffect *mVibrationEffect;
+  bool mHasVibrator;
+};
+
+#endif // agdktunnel_vibration_manager_hpp

--- a/agdk/agdktunnel/app/src/main/java/com/google/sample/agdktunnel/AGDKTunnelActivity.java
+++ b/agdk/agdktunnel/app/src/main/java/com/google/sample/agdktunnel/AGDKTunnelActivity.java
@@ -56,10 +56,6 @@ public class AGDKTunnelActivity extends GameActivity {
         // See https://developer.android.com/ndk/guides/cpp-support#shared_runtimes
         System.loadLibrary("c++_shared");
 
-        // Optional: reload the memory advice library explicitly (it will be loaded
-        // implicitly when loading agdktunnel library as a dependent library)
-        System.loadLibrary("memory_advice");
-
         // Optional: reload the native library.
         // However this is necessary when any of the following happens:
         //     - agdktunnel library is not configured to the following line in the manifest:

--- a/agdk/agdktunnel/library_wrapper/config.json
+++ b/agdk/agdktunnel/library_wrapper/config.json
@@ -1,0 +1,50 @@
+{
+  "custom_classes": [
+    {
+      "class_name": "class java.lang.CharSequence"
+    },
+    {
+      "class_name": "class java.lang.Object",
+      "methods": [
+        "java.lang.String toString()"
+      ]
+    },
+    {
+      "class_name": "class java.lang.String"
+    },
+    {
+      "class_name": "class android.content.Context",
+      "methods": [
+        "java.lang.Object getSystemService(java.lang.String name)"
+      ]
+    },
+    {
+      "class_name": "class android.os.Vibrator",
+      "methods": [
+        "void cancel()",
+        "boolean hasVibrator()",
+        "void vibrate (long milliseconds)",
+        "void vibrate (android.os.VibrationEffect vibe)",
+        "void vibrate (android.os.VibrationEffect vibe, android.os.VibrationAttributes attributes)"
+      ]
+    },
+    {
+      "class_name": "class android.os.VibratorManager",
+      "methods": [
+        "android.os.Vibrator getDefaultVibrator()"
+      ]
+    },
+    {
+      "class_name": "class android.os.VibrationEffect",
+      "methods": [
+        "static android.os.VibrationEffect createPredefined(int effectId)"
+      ]
+    },
+    {
+      "class_name": "class android.os.VibrationAttributes",
+      "methods": [
+        "static android.os.VibrationAttributes createForUsage(int usage)"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Uses native wrapper files generated by the Library Wrapper tool to add a haptic feedback effect when colliding with an obstacle during gameplay.

Updated README with details on Library Wrapper.

Merged a small change to update the Memory Advice API to 2.0-beta03 and link it as a static library instead of shared.