### PR TITLE
[adpf] gettid for PerformanceHintManager

### DIFF
--- a/agdk/adpf/app/src/main/cpp/adpf_manager.cpp
+++ b/agdk/adpf/app/src/main/cpp/adpf_manager.cpp
@@ -189,7 +189,7 @@ bool ADPFManager::InitializePerformanceHintManager() {
 
   // Create int array which contain current tid.
   jintArray array = env->NewIntArray(1);
-  int32_t tid = getpid();
+  int32_t tid = gettid();
   env->SetIntArrayRegion(array, 0, 1, &tid);
   const jlong DEFAULT_TARGET_NS = 16666666;
 

--- a/agdk/game_mode/app/src/main/cpp/adpf_manager.cpp
+++ b/agdk/game_mode/app/src/main/cpp/adpf_manager.cpp
@@ -167,7 +167,7 @@ bool ADPFManager::InitializePerformanceHintManager() {
 
   // Create int array which contain current tid.
   jintArray array = env->NewIntArray(1);
-  int32_t tid = getpid();
+  int32_t tid = gettid();
   env->SetIntArrayRegion(array, 0, 1, &tid);
   const jlong DEFAULT_TARGET_NS = 16666666;
 


### PR DESCRIPTION
Should pass on Thread-ID instead of process-id

https://android.googlesource.com/platform/bionic/+/refs/heads/main/libc/include/unistd.h#84