### PR TITLE
Update Android Studio requirements in READMEs

### DIFF
--- a/agdk/adpf/README.md
+++ b/agdk/adpf/README.md
@@ -15,7 +15,7 @@ The sample:
 
 ## Prerequisites
 
-Before building in Android Studio the following prerequisites must be
+Before building in Android Studio (2022.3 or higher) the following prerequisites must be
 performed:
 
 ## Requirements

--- a/agdk/agdktunnel/README.md
+++ b/agdk/agdktunnel/README.md
@@ -31,7 +31,7 @@ feedback on in-game collisions.
 
 ## Building
 
-Open the `agdktunnel' directory in Android Studio 2021.2 or higher.
+Open the `agdktunnel' directory in Android Studio 2022.3 or higher.
 
 ## Memory Advice
 

--- a/agdk/game_controller/README.md
+++ b/agdk/game_controller/README.md
@@ -12,7 +12,7 @@ such as vibration
 
 ## Prerequisites
 
-Before building in Android Studio the following prerequisites must be
+Before building in Android Studio (2022.3 or higher) the following prerequisites must be
 performed:
 
 ### ImGui

--- a/agdk/game_mode/README.md
+++ b/agdk/game_mode/README.md
@@ -13,7 +13,7 @@ Note that this sample is just demonstrating the easiest and most distinguishable
 
 ## Prerequisites
 
-Before building in Android Studio, the following prerequisites must be met:
+Before building in Android Studio (2022.3 or higher), the following prerequisites must be met:
 
 ### Requirements
 
@@ -25,7 +25,7 @@ game mode functionality will be available.
 
 This sample utilizes 3rd party libraries such as Dear Imgui and Bullet physics. Follow these steps to setup the required libraries:
 
-1. Open a terminal and set the working directory to `agdk/thirdparty/`
+1. Open a terminal and set the working directory to `agdk/third_party/`
 2. Run: `git clone https://github.com/ocornut/imgui`
 3. Run: `git clone https://github.com/bulletphysics/bullet3`
 


### PR DESCRIPTION
Android Studio 2022.3 or higher should now be used to build samples due to AGP version updates.