### PR TITLE
[adpf] gettid for PerformanceHintManager

### DIFF
--- a/agdk/common/src/adpf_manager.cpp
+++ b/agdk/common/src/adpf_manager.cpp
@@ -197,7 +197,7 @@ bool ADPFManager::InitializePerformanceHintManager() {
 
   // Create int array which contain current tid.
   jintArray array = env->NewIntArray(1);
-  int32_t tid = getpid();
+  int32_t tid = gettid();
   env->SetIntArrayRegion(array, 0, 1, &tid);
   const jlong DEFAULT_TARGET_NS = 16666666;
 


### PR DESCRIPTION
Use gittid instead of gitpid for retrieving ids to pass to PerformanceHintManager

Re-do of PR 58 after common code merge pass.