### PR TITLE
Add ETC2 feature flag for Vulkan API, requirement for AGDKTunnel Vulkan

### DIFF
--- a/agdk/agdktunnel/app/src/main/cpp/native_engine.cpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_engine.cpp
@@ -116,13 +116,15 @@ bool NativeEngine::AttemptDisplayInitialization() {
     }
 
     DisplayManager::GraphicsAPI graphics_api = DisplayManager::kGraphicsAPI_Vulkan;
-    uint32_t requested_features = DisplayManager::kVulkan_1_1_Support;
+    uint32_t requested_features = DisplayManager::kVulkan_1_1_Support |
+        DisplayManager::kVulkan_ETC2_Support;
     mIsVulkan = true;
 
     if (vk_api_flags == DisplayManager::kGraphics_API_Unsupported ||
-        ((vk_api_flags & DisplayManager::kVulkan_1_1_Support) == 0) || s_disable_vulkan) {
+        ((vk_api_flags & DisplayManager::kVulkan_1_1_Support) == 0) ||
+        ((vk_api_flags & DisplayManager::kVulkan_ETC2_Support) == 0) || s_disable_vulkan) {
         // Fall back to GLES 3 if Vulkan isn't supported, or isn't at
-        // least a Vulkan 1.1+ device
+        // least a Vulkan 1.1+ device that supports ETC2
         graphics_api = DisplayManager::kGraphicsAPI_GLES;
         requested_features = DisplayManager::kGLES_3_0_Support;
         mIsVulkan = false;

--- a/agdk/common/base_game_framework/include/display_manager.h
+++ b/agdk/common/base_game_framework/include/display_manager.h
@@ -115,7 +115,9 @@ class DisplayManager {
     /** @brief Bit flag if device meets Android Baseline Profile for Vulkan 2021 TODO: */
     kVulkan_Android_Baseline_Profile_2021 = (1U << 16),
     /** @brief Bit flag if device meets Android Baseline Profile for Vulkan 2022 TODO: */
-    kVulkan_Android_Baseline_Profile_2022 = (1U << 17)
+    kVulkan_Android_Baseline_Profile_2022 = (1U << 17),
+    /** @brief Require Vulkan device to include hardware support for ETC2 textures */
+    kVulkan_ETC2_Support = (1U << 18)
   };
 
   /** @brief Enum of result values from ::InitGraphicsAPI */

--- a/agdk/common/base_game_framework/src/vulkan/graphics_api_vulkan.cpp
+++ b/agdk/common/base_game_framework/src/vulkan/graphics_api_vulkan.cpp
@@ -266,6 +266,11 @@ void GraphicsAPIVulkan::QueryDeviceCapabilities(VkPhysicalDevice physical_device
   const uint32_t api_version = PlatformUtilVulkan::GetVulkanApiVersion();
   DetermineAPILevel(api_version, device_properties.properties.apiVersion);
 
+  // Determine if the device has ETC2 texture support
+  if (device_features.features.textureCompressionETC2) {
+      feature_flags_ |= DisplayManager::kVulkan_ETC2_Support;
+  }
+
   DetermineNumericSupport(device_features.features.shaderInt16,
                           shader_float_16_int_8_features, device_16_bit_storage_features);
   // TODO: Android Baseline Profile detection


### PR DESCRIPTION
AGDKTunnel currently uses ETC2 textures by default if PAD isn't active. ETC2 Support is guaranteed by GLES3 but not Vulkan. Fallback to GLES3 if Vulkan device doesn't support ETC2.