### PR TITLE
Update AGDK samples target SDK/gradle versions

### DIFF
--- a/agdk/adpf/README.md
+++ b/agdk/adpf/README.md
@@ -15,7 +15,7 @@ The sample:
 
 ## Prerequisites
 
-Before building in Android Studio (2022.3 or higher) the following prerequisites must be
+Before building in Android Studio 2024.3.1 Patch 1 (Meerkat) the following prerequisites must be
 performed:
 
 ## Requirements

--- a/agdk/adpf/app/build.gradle
+++ b/agdk/adpf/app/build.gradle
@@ -17,18 +17,19 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 35
+    compileSdkVersion 36
     ndkVersion '27.2.12479018'
 
     defaultConfig {
         applicationId 'com.android.example.games.adpf'
         minSdkVersion 24
-        targetSdkVersion 35
-        versionCode     4
-        versionName    '1.2.1'
+        targetSdkVersion 36
+        versionCode     5
+        versionName    '1.2.2'
         externalNativeBuild {
             cmake {
-                arguments '-DANDROID_STL=c++_shared'
+                arguments '-DANDROID_STL=c++_shared',
+                          '-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON'
             }
         }
     }

--- a/agdk/adpf/app/src/main/AndroidManifest.xml
+++ b/agdk/adpf/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
 
   <application
       android:allowBackup="false"
+      android:appCategory="game"
       android:fullBackupContent="false"
       android:icon="@mipmap/ic_launcher"
       android:label="@string/app_name">

--- a/agdk/adpf/build.gradle
+++ b/agdk/adpf/build.gradle
@@ -22,7 +22,7 @@ buildscript {
        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.2'
+        classpath 'com.android.tools.build:gradle:8.9.1'
     }
 }
 

--- a/agdk/adpf/gradle/wrapper/gradle-wrapper.properties
+++ b/agdk/adpf/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/agdk/agdktunnel/README.md
+++ b/agdk/agdktunnel/README.md
@@ -29,7 +29,7 @@ feedback on in-game collisions.
 
 ## Building
 
-Open the `agdktunnel' directory in Android Studio 2024.2.1 Patch 2 or higher.
+Open the `agdktunnel' directory in Android Studio 2024.3.1 Patch 1 (Meerkat) or higher.
 
 ## Library Wrapper notes
 

--- a/agdk/agdktunnel/app/build.gradle
+++ b/agdk/agdktunnel/app/build.gradle
@@ -26,21 +26,22 @@ def usePad = PADEnabled
 def playcoreDir = file('libs/play-core-native-sdk')
 
 android {
-    compileSdkVersion 35
+    compileSdkVersion 36
     ndkVersion '27.2.12479018'
 
     defaultConfig {
         applicationId 'com.google.sample.agdktunnel'
         minSdkVersion 24
-        targetSdkVersion 35
-        versionCode     10
-        versionName    '1.2'
+        targetSdkVersion 36
+        versionCode     124
+        versionName    '1.2.4'
 
         externalNativeBuild {
             cmake {
                 // Define the PLAYCORE_LOCATION directive.
-                arguments "-DANDROID_STL=c++_static",
-                        "-DPLAYCORE_LOCATION=$playcoreDir"
+                arguments "-DANDROID_STL=c++_shared",
+                        "-DPLAYCORE_LOCATION=$playcoreDir",
+                        "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
             }
         }
         ndk {
@@ -57,7 +58,8 @@ android {
             externalNativeBuild {
                 cmake {
                     arguments "-DANDROID_STL=c++_shared",
-                              "-DUSE_ASSET_PACKS=$usePad"
+                              "-DUSE_ASSET_PACKS=$usePad",
+                              "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
                 }
             }
         }
@@ -68,7 +70,8 @@ android {
                         'proguard-rules.pro'
                 cmake {
                     arguments "-DANDROID_STL=c++_shared",
-                              "-DUSE_ASSET_PACKS=$usePad"
+                              "-DUSE_ASSET_PACKS=$usePad",
+                              "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
                 }
             }
             multiDexEnabled true

--- a/agdk/agdktunnel/app/src/main/AndroidManifest.xml
+++ b/agdk/agdktunnel/app/src/main/AndroidManifest.xml
@@ -26,10 +26,10 @@
 
   <application
       android:allowBackup="false"
+      android:appCategory="game"
       android:fullBackupContent="false"
       android:icon="@mipmap/ic_launcher"
-      android:label="@string/app_name"
-      android:usesCleartextTraffic="true">
+      android:label="@string/app_name">
     <meta-data android:name="com.google.android.gms.games.APP_ID"
         android:value="@string/game_services_project_id"/>
     <activity android:name=".AGDKTunnelActivity"

--- a/agdk/agdktunnel/build.gradle
+++ b/agdk/agdktunnel/build.gradle
@@ -22,7 +22,7 @@ buildscript {
        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.2'
+        classpath 'com.android.tools.build:gradle:8.9.1'
     }
 }
 

--- a/agdk/agdktunnel/gradle/wrapper/gradle-wrapper.properties
+++ b/agdk/agdktunnel/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/agdk/game_controller/README.md
+++ b/agdk/game_controller/README.md
@@ -12,8 +12,8 @@ such as vibration
 
 ## Prerequisites
 
-Before building in Android Studio (2022.3 or higher) the following prerequisites must be
-performed:
+Before building in Android Studio 2024.3.1 Patch 1 (Meerkat) or higher the following prerequisites
+must be performed:
 
 ### ImGui
 

--- a/agdk/game_controller/app/build.gradle
+++ b/agdk/game_controller/app/build.gradle
@@ -17,18 +17,19 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 35
+    compileSdkVersion 36
     ndkVersion '27.2.12479018'
 
     defaultConfig {
         applicationId 'com.google.android.games.paddleboat.gamecontrollersample'
         minSdkVersion 24
-        targetSdkVersion 35
-        versionCode     4
-        versionName    '1.1.2'
+        targetSdkVersion 36
+        versionCode     5
+        versionName    '1.1.3'
         externalNativeBuild {
             cmake {
-                arguments '-DANDROID_STL=c++_shared'
+                arguments '-DANDROID_STL=c++_shared',
+                          '-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON'
             }
         }
     }

--- a/agdk/game_controller/app/src/main/AndroidManifest.xml
+++ b/agdk/game_controller/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
   <application
       android:allowBackup="false"
       android:fullBackupContent="false"
+      android:appCategory="game"
       android:icon="@mipmap/ic_launcher"
       android:label="@string/app_name">
     <activity android:name=".PaddleboatDemoActivity"

--- a/agdk/game_controller/build.gradle
+++ b/agdk/game_controller/build.gradle
@@ -22,7 +22,7 @@ buildscript {
        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.2'
+        classpath 'com.android.tools.build:gradle:8.9.1'
     }
 }
 

--- a/agdk/game_controller/gradle/wrapper/gradle-wrapper.properties
+++ b/agdk/game_controller/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/agdk/game_mode/README.md
+++ b/agdk/game_mode/README.md
@@ -13,7 +13,7 @@ Note that this sample is just demonstrating the easiest and most distinguishable
 
 ## Prerequisites
 
-Before building in Android Studio (2022.3 or higher), the following prerequisites must be met:
+Before building in Android Studio 2024.3.1 Patch 1 (Meerkat) or higher, the following prerequisites must be met:
 
 ### Requirements
 

--- a/agdk/game_mode/app/build.gradle
+++ b/agdk/game_mode/app/build.gradle
@@ -17,18 +17,19 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 35
+    compileSdkVersion 36
     ndkVersion '27.2.12479018'
 
     defaultConfig {
         applicationId 'com.android.example.games.game_mode_sample'
         minSdkVersion 24
-        targetSdkVersion 35
-        versionCode     2
-        versionName    '1.2.1'
+        targetSdkVersion 36
+        versionCode     3
+        versionName    '1.2.2'
         externalNativeBuild {
             cmake {
-                arguments '-DANDROID_STL=c++_shared'
+                arguments '-DANDROID_STL=c++_shared',
+                          '-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON'
             }
         }
     }

--- a/agdk/game_mode/build.gradle
+++ b/agdk/game_mode/build.gradle
@@ -22,7 +22,7 @@ buildscript {
        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.2'
+        classpath 'com.android.tools.build:gradle:8.9.1'
     }
 }
 

--- a/agdk/game_mode/gradle/wrapper/gradle-wrapper.properties
+++ b/agdk/game_mode/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Minor update to the AGDK samples:

* Update readmes to reference using the latest stable Android Studio version
* Update target/compile SDK to 36
* Update Gradle/AGP to 8.11.1/8.9.1
* Add ANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON for 16k page support
* Add android:appCategory="game" to manifest to enable backwards compatibility activity config change behavior on API 36