### PR TITLE
Fix minor VVL warnings

### DIFF
--- a/agdk/agdktunnel/app/build.gradle
+++ b/agdk/agdktunnel/app/build.gradle
@@ -33,8 +33,8 @@ android {
         applicationId 'com.google.sample.agdktunnel'
         minSdkVersion 24
         targetSdkVersion 36
-        versionCode     124
-        versionName    '1.2.4'
+        versionCode     125
+        versionName    '1.2.5'
 
         externalNativeBuild {
             cmake {

--- a/agdk/common/base_game_framework/src/android/platform_util_vulkan_android.cpp
+++ b/agdk/common/base_game_framework/src/android/platform_util_vulkan_android.cpp
@@ -110,6 +110,7 @@ void PlatformUtilVulkan::GetRefreshRates(VkPhysicalDevice physical_device,
                                          uint32_t queue_family_index,
                                          std::vector<DisplayManager::DisplaySwapInterval> &
                                          swap_intervals) {
+  swap_intervals.clear();
   SwappyVk_setQueueFamilyIndex(device, queue, queue_family_index);
 
   uint64_t refresh_duration = 0;
@@ -228,6 +229,7 @@ std::vector<const char *> PlatformUtilVulkan::GetRequiredInstanceExtensions(
   instance_extensions.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
   if (enable_validation_layers) {
     instance_extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+    instance_extensions.push_back(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
   }
   // Request the physical device properties 2 extension on 1.0, is core from
   // 1.1+
@@ -240,6 +242,7 @@ std::vector<const char *> PlatformUtilVulkan::GetRequiredInstanceExtensions(
 
 void PlatformUtilVulkan::GetScreenResolutions(const VkSurfaceCapabilitiesKHR &capabilities,
                                               std::vector<DisplayManager::DisplayResolution> &display_resolutions) {
+  display_resolutions.clear();
   const bool rotated = (capabilities.currentTransform & VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR ||
       capabilities.currentTransform & VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR);
   const int32_t display_width = capabilities.currentExtent.width;

--- a/agdk/common/base_game_framework/src/vulkan/graphics_api_vulkan_utils.cpp
+++ b/agdk/common/base_game_framework/src/vulkan/graphics_api_vulkan_utils.cpp
@@ -162,6 +162,7 @@ void VulkanAPIUtils::GetDepthStencilFormats(VkPhysicalDevice physical_device,
 
 void VulkanAPIUtils::GetDisplayFormats(VkPhysicalDevice physical_device, VkSurfaceKHR surface,
                                        std::vector<DisplayManager::DisplayFormat> &display_formats) {
+  display_formats.clear();
   std::vector<DisplayManager::DisplayFormat> depth_stencil_formats;
   VulkanAPIUtils::GetDepthStencilFormats(physical_device, depth_stencil_formats);
 

--- a/agdk/common/simple_renderer/renderer_render_pass_vk.cpp
+++ b/agdk/common/simple_renderer/renderer_render_pass_vk.cpp
@@ -68,8 +68,8 @@ RenderPassVk::RenderPassVk(const RenderPassCreationParams& params)
   subpass_dependency.dstSubpass = 0;
   subpass_dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
   subpass_dependency.srcAccessMask = 0;
-  subpass_dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-  subpass_dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+  subpass_dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+  subpass_dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
 
   VkRenderPassCreateInfo render_pass_create_info =
       { VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO };


### PR DESCRIPTION
Fixes a couple minor Vulkan Validation Layer warnings:

* Enable additional validation layer features
* Move physical device surface queries to after device creation
* Mark depth/stencil attachments as transient and fix their
  dependency flag bits
* Fix issue where frame completion semaphore count needed
  to match the number of potential swapchain images, not just
  the in-flight frame count