### PR TITLE
Fix gap on right side of screen in game_controller demo

### DIFF
--- a/agdk/game_controller/app/src/main/cpp/demo_scene.cpp
+++ b/agdk/game_controller/app/src/main/cpp/demo_scene.cpp
@@ -278,7 +278,7 @@ void DemoScene::SetupUIWindow() {
     ImGuiIO &io = ImGui::GetIO();
     const float windowStartY = NativeEngine::GetInstance()->GetSystemBarOffset();
     ImVec2 windowPosition(0.0f, windowStartY);
-    ImVec2 minWindowSize(io.DisplaySize.x * 0.95f, io.DisplaySize.y);
+    ImVec2 minWindowSize(io.DisplaySize.x, io.DisplaySize.y);
     ImVec2 maxWindowSize = io.DisplaySize;
     ImGui::SetNextWindowPos(windowPosition);
     ImGui::SetNextWindowSizeConstraints(minWindowSize, maxWindowSize, NULL, NULL);


### PR DESCRIPTION
There is empty space in the game_controller demo on the right hand side of the screen. Removing the * 0.95 modifier fixes it.
![Screenshot_20240409 (1)](https://github.com/user-attachments/assets/02cc8fa4-1f29-4e89-a4d0-9a7c9ee88438)
 