### PR TITLE
Fix black screen after lock screen cycle

### DIFF
--- a/agdk/agdktunnel/app/src/main/cpp/native_engine.cpp
+++ b/agdk/agdktunnel/app/src/main/cpp/native_engine.cpp
@@ -410,7 +410,6 @@ void NativeEngine::LifecycleEvent(const SystemEventManager::LifecycleEvent lifec
             SceneManager::GetInstance()->OnPause();
         break;
         case SystemEventManager::kLifecycleStop:
-            mHasStarted = false;
         break;
         case SystemEventManager::kLifecycleQuit:
             mQuitting = true;

--- a/agdk/common/base_game_framework/src/android/display_manager_android.cpp
+++ b/agdk/common/base_game_framework/src/android/display_manager_android.cpp
@@ -32,6 +32,9 @@ void DisplayManager::HandlePlatformDisplayChange(const DisplayChangeMessage& cha
       // new window and a new surface
       if (active_api_ == kGraphicsAPI_GLES && api_->GetAPIStatus() == kGraphicsAPI_Active) {
         api_gles_->RestoreSurfaceGLES();
+        api_->SwapchainChanged(kSwapchain_Gained_Window);
+      } else if (active_api_ == kGraphicsAPI_Vulkan && api_->GetAPIStatus() == kGraphicsAPI_Active) {
+        api_->SwapchainChanged(kSwapchain_Gained_Window);
       }
     }
   }

--- a/agdk/common/base_game_framework/src/gles/graphics_api_gles.cpp
+++ b/agdk/common/base_game_framework/src/gles/graphics_api_gles.cpp
@@ -442,7 +442,14 @@ void GraphicsAPIGLES::LostSurfaceGLES() {
 void GraphicsAPIGLES::RestoreSurfaceGLES() {
   egl_surface_ = InitializeEGLSurface(swapchain_format_);
   if (egl_surface_ != nullptr) {
-    PlatformUtilGLES::RestoreSurface();
+    if (eglMakeCurrent(egl_display_, egl_surface_, egl_surface_, egl_context_) == EGL_TRUE) {
+      PlatformUtilGLES::RestoreSurface();
+    } else {
+      DebugManager::Log(DebugManager::kLog_Channel_Default,
+                        DebugManager::kLog_Level_Error,
+                        BGM_CLASS_TAG,
+                        "RestoreSurfaceGLES failed to set current with new EGLSurface");
+    }
   } else {
     DebugManager::Log(DebugManager::kLog_Channel_Default,
                       DebugManager::kLog_Level_Error,

--- a/agdk/common/base_game_framework/src/vulkan/graphics_api_vulkan.cpp
+++ b/agdk/common/base_game_framework/src/vulkan/graphics_api_vulkan.cpp
@@ -757,6 +757,15 @@ bool GraphicsAPIVulkan::SetSwapchainChangedCallback(
 }
 
 void GraphicsAPIVulkan::SwapchainChanged(const DisplayManager::SwapchainChangeMessage message) {
+  if (message == DisplayManager::kSwapchain_Lost_Window && vk_surface_ != VK_NULL_HANDLE) {
+    PlatformUtilVulkan::DestroySurface(vk_instance_, vk_surface_);
+    vk_surface_ = VK_NULL_HANDLE;
+  } else if (message == DisplayManager::kSwapchain_Gained_Window && vk_swapchain_ != VK_NULL_HANDLE) {
+    if (vk_surface_ == VK_NULL_HANDLE) {
+      vk_surface_ = PlatformUtilVulkan::CreateSurface(vk_instance_);
+    }
+    RecreateSwapchain();
+  }
   if (swapchain_changed_callback_ != nullptr) {
     swapchain_changed_callback_(message, swapchain_changed_user_data_);
   }


### PR DESCRIPTION
Fix a bug of failure to properly recreate
necessary surfaces and regeneate the swapchain
if the app went through a full stop/start
lifecycle. This could often be triggered by
locking then unlocking a device.