### PR TITLE
Fix: Support 16KB page sizes and update core dependencies.

### DIFF
--- a/agdk/agdktunnel/app/build.gradle
+++ b/agdk/agdktunnel/app/build.gradle
@@ -27,7 +27,7 @@ def playcoreDir = file('libs/play-core-native-sdk')
 
 android {
     compileSdkVersion 36
-    ndkVersion '27.2.12479018'
+    ndkVersion "28.0.12674087"
 
     defaultConfig {
         applicationId 'com.google.sample.agdktunnel'
@@ -112,13 +112,12 @@ dependencies {
     implementation "androidx.core:core:1.5.0"
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
     implementation 'androidx.fragment:fragment:1.2.5'
-    implementation 'com.google.oboe:oboe:1.5.0'
-    implementation "androidx.games:games-frame-pacing:2.1.2"
+    implementation 'com.google.oboe:oboe:1.10.0'
+    implementation "androidx.games:games-frame-pacing:2.1.3"
     implementation "androidx.games:games-activity:3.0.5"
     implementation "androidx.games:games-controller:2.0.2"
 
-    // Dependency for using APIs wrapped using library wrapper
-    implementation 'com.google.android.gms:play-services-gni-native-c:1.0.0-beta2'
+    implementation "com.google.android.gms:play-services-games-v2-native-c:21.0.0-beta1"
 
     // Google Play Games dependencies
     implementation "com.google.android.gms:play-services-games-v2:17.0.0"

--- a/agdk/agdktunnel/app/src/main/cpp/CMakeLists.txt
+++ b/agdk/agdktunnel/app/src/main/cpp/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(oboe REQUIRED CONFIG)
 find_package(game-activity REQUIRED CONFIG)
 find_package(games-controller REQUIRED CONFIG)
 find_package(games-frame-pacing REQUIRED CONFIG)
-find_package(com.google.android.gms.gni.c REQUIRED CONFIG)
+find_package(com.google.android.gms.games.v2.c REQUIRED CONFIG)
 
 # Set the base dir
 set(GAMESDK_BASE_DIR "../../../../..")
@@ -152,7 +152,7 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
 
 # add lib dependencies
 target_link_libraries(${CMAKE_PROJECT_NAME}
-     PUBLIC com.google.android.gms.gni.c::gni_shared
+     PUBLIC com.google.android.gms.games.v2.c::games_static
      android
      atomic
      c++
@@ -178,3 +178,5 @@ else()
 
     target_link_libraries(${CMAKE_PROJECT_NAME} playcore)
 endif()
+
+target_link_options(${CMAKE_PROJECT_NAME} PRIVATE "-Wl,-z,max-page-size=16384")


### PR DESCRIPTION
This PR updates the build configuration and dependencies to support 16KB page sizes.

Fixes https://github.com/android/games-samples/issues/99