### PR TITLE
update Unity to 6000.3.15f1 and Purchasing to 5.3.0

### DIFF
--- a/trivialkart/trivialkart-unity/Assets/Resources/BillingMode.json
+++ b/trivialkart/trivialkart-unity/Assets/Resources/BillingMode.json
@@ -1,0 +1,1 @@
+{"androidStore":"GooglePlay"}

--- a/trivialkart/trivialkart-unity/Assets/Resources/BillingMode.json.meta
+++ b/trivialkart/trivialkart-unity/Assets/Resources/BillingMode.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 312593d19cf548a44979366b183f1271
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/trivialkart/trivialkart-unity/Packages/manifest.json
+++ b/trivialkart/trivialkart-unity/Packages/manifest.json
@@ -1,10 +1,11 @@
 {
   "dependencies": {
-    "com.unity.inputsystem": "1.14.2",
-    "com.unity.multiplayer.center": "1.0.0",
-    "com.unity.purchasing": "5.0.1",
+    "com.unity.inputsystem": "1.19.0",
+    "com.unity.multiplayer.center": "1.0.1",
+    "com.unity.purchasing": "5.3.0",
     "com.unity.ugui": "2.0.0",
     "com.unity.modules.accessibility": "1.0.0",
+    "com.unity.modules.adaptiveperformance": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
@@ -31,6 +32,7 @@
     "com.unity.modules.unitywebrequestaudio": "1.0.0",
     "com.unity.modules.unitywebrequesttexture": "1.0.0",
     "com.unity.modules.unitywebrequestwww": "1.0.0",
+    "com.unity.modules.vectorgraphics": "1.0.0",
     "com.unity.modules.vehicles": "1.0.0",
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",

--- a/trivialkart/trivialkart-unity/Packages/packages-lock.json
+++ b/trivialkart/trivialkart-unity/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.inputsystem": {
-      "version": "1.14.2",
+      "version": "1.19.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -10,7 +10,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.multiplayer.center": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "depth": 0,
       "source": "builtin",
       "dependencies": {
@@ -18,14 +18,14 @@
       }
     },
     "com.unity.nuget.newtonsoft-json": {
-      "version": "3.2.1",
+      "version": "3.2.2",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.purchasing": {
-      "version": "5.0.1",
+      "version": "5.3.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -38,7 +38,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.services.core": {
-      "version": "1.14.0",
+      "version": "1.16.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -62,6 +62,14 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {}
+    },
+    "com.unity.modules.adaptiveperformance": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.subsystems": "1.0.0"
+      }
     },
     "com.unity.modules.ai": {
       "version": "1.0.0",
@@ -205,7 +213,8 @@
         "com.unity.modules.ui": "1.0.0",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0",
-        "com.unity.modules.hierarchycore": "1.0.0"
+        "com.unity.modules.hierarchycore": "1.0.0",
+        "com.unity.modules.physics": "1.0.0"
       }
     },
     "com.unity.modules.umbra": {
@@ -267,6 +276,16 @@
         "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.assetbundle": "1.0.0",
         "com.unity.modules.imageconversion": "1.0.0"
+      }
+    },
+    "com.unity.modules.vectorgraphics": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.uielements": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0"
       }
     },
     "com.unity.modules.vehicles": {

--- a/trivialkart/trivialkart-unity/ProjectSettings/ProjectVersion.txt
+++ b/trivialkart/trivialkart-unity/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.1.4f1
-m_EditorVersionWithRevision: 6000.1.4f1 (03270eb687c6)
+m_EditorVersion: 6000.3.15f1
+m_EditorVersionWithRevision: 6000.3.15f1 (c1aa84e375f6)


### PR DESCRIPTION
## Description
This PR updates the project's Unity engine version and the `com.unity.purchasing` package. This is a critical maintenance update to resolve a known engine security vulnerability and ensure compliance with the latest Google Play Billing Library (PBL).

## Motivation and Context
*   **Security & Stability:** The previously used Unity version (`6000.1.4f1`) is not a Long Term Support (LTS) release and contains a known vulnerability documented in the [Unity Security Update Advisory](https://unity.com/security/sept-2025-01). 
*   **Billing Requirements:** The previous purchasing package (`5.0.1`) relied on the outdated PBL `8.0.0`. This update safely brings us to the current PBL `8.3.0`.

## Changes Made
*   Upgraded Unity editor version from `6000.1.4f1` to `6000.3.15f1`
*   Upgraded `com.unity.purchasing` from `5.0.1` to `5.3.0`
*   Committed `Assets/Resources/BillingMode.json` to version control (generated by Unity's purchasing package)

## Testing Performed
*   Successfully created a new build with the updated engine and packages.
*   Verified runtime functionality on the post-update build to ensure no regressions.