### PR TITLE
AGDKTunnel 1.2.5

### DIFF
--- a/agdk/agdktunnel/README.md
+++ b/agdk/agdktunnel/README.md
@@ -26,10 +26,13 @@ feedback on in-game collisions.
 1. cd to `agdk/third_party`
 2. git clone https://github.com/zeux/volk.git
 3. git clone https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git
+4. Download and install the Vulkan SDK for the `glslc` compiler
+5. Create or edit the `local.properties` file in this directory to add a `glslc.dir` pointing
+to the directory with the `glslc` compiler (i.e. glslc.dir=/Users/foo/VulkanSDK/1.4.341.1/macOS/bin)
 
 ## Building
 
-Open the `agdktunnel' directory in Android Studio 2024.3.1 Patch 1 (Meerkat) or higher.
+Open the `agdktunnel' directory in Android Studio 2026.1.1 Patch 1 (Quail 1) or higher.
 
 ## Library Wrapper notes
 
@@ -104,6 +107,7 @@ For more information see the codelab: [Using Play Asset Delivery in native games
 
 ## Version history
 
+1.2.5 - Updatd to current AGDK/NDK/AGP versions, 16KB page compatible fix
 1.2.1 - Updated to current AGDK/NDK/AGP versions, deprecated Android Performance Tuner integration
 1.2.0 - Major refactor to add basegameframework support, Vulkan/GLES simplerenderer, updating AGDK versions
 1.0.4 - Merged Play integrations from AOSP. Play Asset Delivery,

--- a/agdk/agdktunnel/README.md
+++ b/agdk/agdktunnel/README.md
@@ -107,7 +107,7 @@ For more information see the codelab: [Using Play Asset Delivery in native games
 
 ## Version history
 
-1.2.5 - Updatd to current AGDK/NDK/AGP versions, 16KB page compatible fix
+1.2.5 - Updated to current AGDK/NDK/AGP versions, 16KB page compatible fix
 1.2.1 - Updated to current AGDK/NDK/AGP versions, deprecated Android Performance Tuner integration
 1.2.0 - Major refactor to add basegameframework support, Vulkan/GLES simplerenderer, updating AGDK versions
 1.0.4 - Merged Play integrations from AOSP. Play Asset Delivery,

--- a/agdk/agdktunnel/app/build.gradle
+++ b/agdk/agdktunnel/app/build.gradle
@@ -26,15 +26,15 @@ def usePad = PADEnabled
 def playcoreDir = file('libs/play-core-native-sdk')
 
 android {
-    compileSdkVersion 36
-    ndkVersion '27.2.12479018'
+    compileSdkVersion 37
+    ndkVersion '29.0.14206865'
 
     defaultConfig {
         applicationId 'com.google.sample.agdktunnel'
         minSdkVersion 24
-        targetSdkVersion 36
-        versionCode     125
-        versionName    '1.2.5'
+        targetSdkVersion 37
+        versionCode     126
+        versionName    '1.2.6'
 
         externalNativeBuild {
             cmake {
@@ -51,7 +51,7 @@ android {
     buildTypes {
         release {
             minifyEnabled = false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'),
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),
                     'proguard-rules.pro',
                     '$playcoreDir/proguard/common.pgcfg',
                     '$playcoreDir/proguard/per-feature-proguard-files'
@@ -66,7 +66,7 @@ android {
         debug {
             externalNativeBuild {
                 minifyEnabled = false
-                proguardFiles getDefaultProguardFile('proguard-android.txt'),
+                proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),
                         'proguard-rules.pro'
                 cmake {
                     arguments "-DANDROID_STL=c++_shared",
@@ -106,22 +106,23 @@ android {
 }
 
 dependencies {
-    implementation "androidx.lifecycle:lifecycle-viewmodel:2.2.0"
-    implementation "androidx.lifecycle:lifecycle-livedata:2.2.0"
-    implementation "androidx.lifecycle:lifecycle-runtime:2.2.0"
-    implementation "androidx.core:core:1.5.0"
-    implementation "androidx.constraintlayout:constraintlayout:2.0.4"
-    implementation 'androidx.fragment:fragment:1.2.5'
-    implementation 'com.google.oboe:oboe:1.5.0'
-    implementation "androidx.games:games-frame-pacing:2.1.2"
-    implementation "androidx.games:games-activity:3.0.5"
+    implementation "androidx.appcompat:appcompat:1.6.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel:2.10.0"
+    implementation "androidx.lifecycle:lifecycle-livedata:2.10.0"
+    implementation "androidx.lifecycle:lifecycle-runtime:2.10.0"
+    implementation "androidx.core:core:1.19.0"
+    implementation "androidx.constraintlayout:constraintlayout:2.2.1"
+    implementation 'androidx.fragment:fragment:1.8.9'
+    implementation 'com.google.oboe:oboe:1.10.0'
+    implementation "androidx.games:games-frame-pacing:2.1.3"
+    implementation "androidx.games:games-activity:4.4.2"
     implementation "androidx.games:games-controller:2.0.2"
 
     // Dependency for using APIs wrapped using library wrapper
     implementation 'com.google.android.gms:play-services-gni-native-c:1.0.0-beta2'
 
     // Google Play Games dependencies
-    implementation "com.google.android.gms:play-services-games-v2:17.0.0"
+    implementation "com.google.android.gms:play-services-games-v2:21.0.0"
     // Use the Play Core AAR included with the SDK.
     if(PADEnabled.toBoolean()) {
         implementation files("$playcoreDir/playcore.aar")

--- a/agdk/agdktunnel/build.gradle
+++ b/agdk/agdktunnel/build.gradle
@@ -22,7 +22,7 @@ buildscript {
        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.9.1'
+        classpath 'com.android.tools.build:gradle:8.13.2'
     }
 }
 

--- a/agdk/agdktunnel/build.gradle
+++ b/agdk/agdktunnel/build.gradle
@@ -22,7 +22,7 @@ buildscript {
        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.2'
+        classpath 'com.android.tools.build:gradle:9.2.1'
     }
 }
 

--- a/agdk/agdktunnel/gradle.properties
+++ b/agdk/agdktunnel/gradle.properties
@@ -15,12 +15,11 @@
 #android.enableJetifier=true
 android.useAndroidX=true
 
-android.prefabVersion=2.0.0
-
 GameSDKPath=../..
 
 # Set to true to delivery optimized compressed assets using the Play Asset Delivery API
 PADEnabled=false
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
-android.nonFinalResIds=false
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false

--- a/agdk/agdktunnel/gradle/wrapper/gradle-wrapper.properties
+++ b/agdk/agdktunnel/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/agdk/agdktunnel/gradle/wrapper/gradle-wrapper.properties
+++ b/agdk/agdktunnel/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/agdk/agdktunnel/settings.gradle
+++ b/agdk/agdktunnel/settings.gradle
@@ -1,4 +1,6 @@
-/*
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
+}/*
  * Copyright 2021 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Bring AGDKTunnel up to date with current Gradle/AGP/NDK/AGDK versions. 16KB page compatible.