### PR TITLE
Compile with static version of com.google.android.gms.gni.c to fix 16…

### DIFF
--- a/agdk/agdktunnel/app/src/main/cpp/CMakeLists.txt
+++ b/agdk/agdktunnel/app/src/main/cpp/CMakeLists.txt
@@ -152,7 +152,7 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
 
 # add lib dependencies
 target_link_libraries(${CMAKE_PROJECT_NAME}
-     PUBLIC com.google.android.gms.gni.c::gni_shared
+     PUBLIC com.google.android.gms.gni.c::gni_static
      android
      atomic
      c++


### PR DESCRIPTION
…ki warning

com.google.android.gms.gni.c::gni_shared isn't 16 KiB aligned and is causing the sample to throw a warning. Statically compile the library instead to avoid this.