### PR TITLE
build: integrate Visual Studio editor package and update gitignore

### DIFF
--- a/trivialkart/trivialkart-unity/.gitignore
+++ b/trivialkart/trivialkart-unity/.gitignore
@@ -43,6 +43,7 @@ ExportedObj/
 *.csproj
 *.unityproj
 *.sln
+*.slnx
 *.suo
 *.tmp
 *.user

--- a/trivialkart/trivialkart-unity/.vsconfig
+++ b/trivialkart/trivialkart-unity/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+}

--- a/trivialkart/trivialkart-unity/Packages/manifest.json
+++ b/trivialkart/trivialkart-unity/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.unity.ide.visualstudio": "2.0.27",
     "com.unity.inputsystem": "1.19.0",
     "com.unity.multiplayer.center": "1.0.1",
     "com.unity.purchasing": "5.3.0",

--- a/trivialkart/trivialkart-unity/Packages/packages-lock.json
+++ b/trivialkart/trivialkart-unity/Packages/packages-lock.json
@@ -1,5 +1,20 @@
 {
   "dependencies": {
+    "com.unity.ext.nunit": {
+      "version": "2.0.5",
+      "depth": 2,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.ide.visualstudio": {
+      "version": "2.0.27",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.1.33"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.inputsystem": {
       "version": "1.19.0",
       "depth": 0,
@@ -47,6 +62,16 @@
         "com.unity.modules.unitywebrequest": "1.0.0"
       },
       "url": "https://packages.unity.com"
+    },
+    "com.unity.test-framework": {
+      "version": "1.6.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.ext.nunit": "2.0.3",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      }
     },
     "com.unity.ugui": {
       "version": "2.0.0",


### PR DESCRIPTION
- Added the Visual Studio Editor Unity package (`com.unity.ide.visualstudio`) to `Packages/manifest.json` to enable richer IDE integration (such as debugging and project generation).
- Updated `Packages/packages-lock.json` with the new package and its resolved dependencies (`com.unity.test-framework` and `com.unity.ext.nunit`).
- Updated `.gitignore` to ignore`*.slnx` to keep the repository clean of autogenerated solution files.